### PR TITLE
Audio Encoder to bfloat16

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 # Core
-transformers[torch]>=4.39.3
+transformers[torch]>=4.40.2
 bitsandbytes>=0.42.0
 peft
 simple_parsing

--- a/ultravox/training/train.py
+++ b/ultravox/training/train.py
@@ -174,9 +174,7 @@ def main() -> None:
     logging.info(
         f"Using dtype and device (world_size): {dtype}, {device} ({world_size})"
     )
-    model.to(device)
-    model.language_model.to(dtype)
-    model.multi_modal_projector.to(dtype)
+    model.to(device=device, dtype=dtype)
     # TODO: check if the whole model can now be moved to dtype instead
 
     # Prepare dataset, subsetting if needed


### PR DESCRIPTION
With the recent patch from [HF Transformers for Wav2Vec2](https://x.com/kamilakesbi/status/1782780288243749186), we can train the audio encoder, whether it's wav2vec2 or Whisper, with bfloat16, so there's no need to have an exception for it.

This change seems to have landed on 4.40.2 (as verified by an experiment and the timing between the PR merge and PyPi version), so I'm increasing our minimum requirement for it:
![image](https://github.com/fixie-ai/ultravox/assets/5062458/1dca7582-3ef2-4126-bd11-f2ca2fa6f584)

W&B task for verification:
https://wandb.ai/fixie/ultravox/runs/lygf6hbn/overview
![image](https://github.com/fixie-ai/ultravox/assets/5062458/8bdbd122-9c49-4ef1-acec-d1479dea0cb2)
