### PR TITLE
Fixes the default HF model name

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ brew install just
 Create a Python virtual environment and install the necessary packages:
 
 ```bash
-just create-env
+just create-venv
 ```
 
 For now we're using venv for Python virtual environments.

--- a/ultravox/tools/infer_tool.py
+++ b/ultravox/tools/infer_tool.py
@@ -28,7 +28,7 @@ DEFAULT_ASR_PROMPT = "Transcribe <|audio|>"
 @dataclasses.dataclass
 class InferArgs:
     # Model ID to use for the model
-    model: str = simple_parsing.field(default="fixie-ai/ultravox", alias="-m")
+    model: str = simple_parsing.field(default="fixie-ai/ultravox-v0.2", alias="-m")
     # Path to the audio file
     audio_file: Optional[IO] = simple_parsing.field(
         default=None, type=argparse.FileType("rb"), alias="-f"

--- a/ultravox/tools/infer_tool.py
+++ b/ultravox/tools/infer_tool.py
@@ -28,7 +28,7 @@ DEFAULT_ASR_PROMPT = "Transcribe <|audio|>"
 @dataclasses.dataclass
 class InferArgs:
     # Model ID to use for the model
-    model: str = simple_parsing.field(default="fixie-ai/ultravox-v0.1", alias="-m")
+    model: str = simple_parsing.field(default="fixie-ai/ultravox", alias="-m")
     # Path to the audio file
     audio_file: Optional[IO] = simple_parsing.field(
         default=None, type=argparse.FileType("rb"), alias="-f"


### PR DESCRIPTION
Fixes the default HF model name. On HF model is named [fixie-ai/ultravox](https://huggingface.co/fixie-ai/ultravox) and not [fixie-ai/ultravox-v0.1](https://huggingface.co/search/full-text?q=%22fixie-ai%2Fultravox-v0.1%22&type=model).

Also fixes small misspelling for the env setup for `just` : The `create-env` command does not exist but `create-venv` does :-).