### PR TITLE
Update Hugging Face link

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ where `data.json` contains:
 
 ### Model
 
-You can download the latest weights from the [Ultravox Hugging Face page](https://huggingface.co/fixie-ai/ultravox).
+You can download the latest weights from the [Ultravox Hugging Face page](https://huggingface.co/fixie-ai/ultravox-v0.2).
 
 ### Architecture
 


### PR DESCRIPTION
The previous page says it has been deprecated in favor of this one.

https://huggingface.co/fixie-ai/ultravox

![image](https://github.com/fixie-ai/ultravox/assets/9599/66d5975d-57af-4754-b10a-7d7ec6e2d0c7)
