### PR TITLE
More validations

### DIFF
--- a/ultravox/data/datasets.py
+++ b/ultravox/data/datasets.py
@@ -218,7 +218,7 @@ class VoiceDatasetArgs:
 
 
 def _get_messages(
-    *turns: List[str], sys_prompt: Optional[str] = None, assistant_last: bool = True
+    *turns: str, sys_prompt: Optional[str] = None, assistant_last: bool = True
 ) -> List[Dict[str, str]]:
     """
     Convert a list of strings into a list of messages, alternating between user and assistant.

--- a/ultravox/data/datasets.py
+++ b/ultravox/data/datasets.py
@@ -779,10 +779,10 @@ class CommonVoiceDataset(VoiceDataset):
     NOTE: requires HF login
     """
 
-    def __init__(self, args: VoiceDatasetArgs) -> None:
+    def __init__(self, args: VoiceDatasetArgs, lang: str = "en") -> None:
         super().__init__(args)
         dataset = self._load_audio_dataset(
-            "mozilla-foundation/common_voice_16_1", "en", split=args.split.value
+            "mozilla-foundation/common_voice_16_1", lang, split=args.split.value
         )
         self._init_dataset(dataset)
 
@@ -873,7 +873,8 @@ def create_dataset(name: str, args: VoiceDatasetArgs) -> data.IterableDataset:
         "soda": SodaDataset,
         "dummy": LibriSpeechDummyDataset,
     }
-    return DATASET_MAP[name](args)
+    name, *ext = name.split(":")
+    return DATASET_MAP[name](args, *ext)
 
 
 class InterleaveDataset(data.IterableDataset):

--- a/ultravox/data/datasets.py
+++ b/ultravox/data/datasets.py
@@ -293,7 +293,6 @@ class VoiceDataset(abc.ABC, data.IterableDataset):
         Converts a row from the dataset into a VoiceSample.
         Returns None if the sample should be skipped.
         """
-        pass
 
     def _choice(self, prompts: List[str]) -> str:
         return self._rng.choice(prompts[: self._args.num_prompts])

--- a/ultravox/data/datasets.py
+++ b/ultravox/data/datasets.py
@@ -629,7 +629,10 @@ class HeySQuADHumanDataset(QAVoiceDatasetMixin):
             Question: {question}
             <|assistant|> {answer}
         """
-        if len(row["context"]) > self._args.max_context_length or not row["answers"]:
+        if row["is_impossible"] or not row["answers"]:
+            # Skip samples with no answer
+            return None
+        if len(row["context"]) > self._args.max_context_length:
             # Skip samples with long context
             return None
 

--- a/ultravox/data/datasets.py
+++ b/ultravox/data/datasets.py
@@ -489,7 +489,7 @@ class BoolQDataset(VoiceDataset):
         )
         self._init_dataset(dataset)
 
-    def _get_sample(self, row: transformers.BatchFeature) -> VoiceSample:
+    def _get_sample(self, row: transformers.BatchFeature) -> Optional[VoiceSample]:
         question = row["question"]
         answer = "True" if row["answer"] else "False"
         context = row["passage"] if self._args.include_context else None

--- a/ultravox/data/datasets_test.py
+++ b/ultravox/data/datasets_test.py
@@ -126,11 +126,11 @@ def test_num_prompts():
     )
     assert (
         samples[2].messages[0]["content"]
-        == "Transcribe exactly what is said here <|audio|>"
+        == "Transcribe exactly what is said here\n<|audio|>"
     )
     assert (
         samples[3].messages[0]["content"]
-        == "Transcribe exactly what is said here <|audio|>"
+        == "Transcribe exactly what is said here\n<|audio|>"
     )
 
 

--- a/ultravox/data/datasets_test.py
+++ b/ultravox/data/datasets_test.py
@@ -108,7 +108,7 @@ def test_transcribe_dataset():
     sample = next(iter(ds))
     assert isinstance(sample, datasets.VoiceSample)
     assert sample.messages == [
-        {"role": "user", "content": "Transcribe <|audio|>"},
+        {"role": "user", "content": "Transcribe\n<|audio|>"},
         {"role": "assistant", "content": "0"},
     ]
     assert np.array_equal(sample.audio, np.zeros(256))
@@ -119,7 +119,7 @@ def test_transcribe_dataset():
 def test_num_prompts():
     ds = FakeTranscribeDataset(5, datasets.VoiceDatasetArgs(num_prompts=3))
     samples = list(ds)
-    assert samples[0].messages[0]["content"] == "Transcribe <|audio|>"
+    assert samples[0].messages[0]["content"] == "Transcribe\n<|audio|>"
     assert (
         samples[1].messages[0]["content"]
         == "Repeat exactly what is written here: <|audio|>"
@@ -168,14 +168,14 @@ def _create_and_validate_sample(target_dtype: str = "float32"):
     # kHz, with an amplitude of 0.1, and the specified dtype.
     array = _create_sine_wave(target_dtype=target_dtype)
     sample = datasets.VoiceSample.from_prompt_and_raw(
-        "Transcribe <|audio|>", array, 16000
+        "Transcribe\n<|audio|>", array, 16000
     )
     assert sample.sample_rate == 16000
     assert sample.audio is not None, "sample.audio should not be None"
     assert len(sample.audio) == 16000
     assert sample.audio.dtype == np.float32
     assert sample.messages == [
-        {"role": "user", "content": "Transcribe <|audio|>"},
+        {"role": "user", "content": "Transcribe\n<|audio|>"},
     ]
     # Serialize and deserialize the sample.
     json = sample.to_json()
@@ -208,5 +208,29 @@ def test_create_sample__raises_on_unsupported_dtype():
     with pytest.raises(AssertionError):
         array = np.ndarray(shape=(16000,), dtype=np.uint8)
         sample = datasets.VoiceSample.from_prompt_and_raw(
-            "Transcribe <|audio|>", array, 16000
+            "Transcribe\n<|audio|>", array, 16000
         )
+
+
+def test_get_messages():
+    messages = datasets._get_messages("Yo!", "Hi!")
+    assert messages == [
+        {"role": "user", "content": "Yo!"},
+        {"role": "assistant", "content": "Hi!"},
+    ]
+
+    messages = datasets._get_messages(
+        "Yo!", "Hi!", assistant_last=False, sys_prompt="Be nice!"
+    )
+    assert messages == [
+        {"role": "system", "content": "Be nice!"},
+        {"role": "assistant", "content": "Yo!"},
+        {"role": "user", "content": "Hi!"},
+    ]
+
+    messages = datasets._get_messages("A", "B", "C")
+    assert messages == [
+        {"role": "assistant", "content": "A"},
+        {"role": "user", "content": "B"},
+        {"role": "assistant", "content": "C"},
+    ]

--- a/ultravox/inference/infer_test.py
+++ b/ultravox/inference/infer_test.py
@@ -66,7 +66,7 @@ def test_infer_16kHz(tokenizer, audio_processor):
     inference = FakeInference(tokenizer, audio_processor)
     array = np.ones(16000, dtype=np.float32)
     sample = datasets.VoiceSample.from_prompt_and_raw(
-        "Transcribe <|audio|>", array, 16000
+        "Transcribe\n<|audio|>", array, 16000
     )
     output = inference.infer(sample)
     assert output.input_tokens == 20
@@ -89,7 +89,7 @@ def test_infer_48kHz(tokenizer, audio_processor):
     inference = FakeInference(tokenizer, audio_processor)
     array = np.ones(48000, dtype=np.float32)
     sample = datasets.VoiceSample.from_prompt_and_raw(
-        "Transcribe <|audio|>", array, 48000
+        "Transcribe\n<|audio|>", array, 48000
     )
     output = inference.infer(sample)
     assert output.input_tokens == 20
@@ -112,7 +112,7 @@ def test_infer_16kHz_stream(tokenizer, audio_processor):
     inference = FakeInference(tokenizer, audio_processor)
     array = np.ones(16000, dtype=np.float32)
     sample = datasets.VoiceSample.from_prompt_and_raw(
-        "Transcribe <|audio|>", array, 16000
+        "Transcribe\n<|audio|>", array, 16000
     )
     gen = inference.infer_stream(sample)
     text = ""

--- a/ultravox/model/data_processing.py
+++ b/ultravox/model/data_processing.py
@@ -74,7 +74,7 @@ class UltravoxDataproc(datasets.Dataproc):
             # One reason is that there's very little randomness in the prompt, so the model would be forced to memorize it.
             #
             # Example (-100 is the ignore index):
-            #   Tokens: <user> Transcribe <|audio|> </s> <assistant> Brown fox jumps over the lazy dog </s>
+            #   Tokens: <user> Transcribe\n<|audio|> </s> <assistant> Brown fox jumps over the lazy dog </s>
             #   Labels:  -100    -100       -100    -100 <assistant> Brown fox jumps over the lazy dog </s>
             #
             # Note: The above might look weird because I'm mixing token IDs and text, but that's just for illustration.

--- a/ultravox/model/ultravox_processing.py
+++ b/ultravox/model/ultravox_processing.py
@@ -152,7 +152,7 @@ class UltravoxProcessor(transformers.ProcessorMixin):
                 data["audio_token_start_idx"] = [start_idx]
 
                 # Replace the audio placeholder with the audio token.
-                #   e.g. "Transcribe <|audio|>" -> "Transcribe </s></s></s></s></s></s></s></s>"
+                #   e.g. "Transcribe\n<|audio|>" -> "Transcribe </s></s></s></s></s></s></s></s>"
                 #        where the number of </s> is the number of audio frames.
                 text = text.replace(
                     self.audio_placeholder,

--- a/ultravox/model/ultravox_processing.py
+++ b/ultravox/model/ultravox_processing.py
@@ -225,11 +225,12 @@ class UltravoxDataproc(datasets.Dataproc):
         )
 
         # Extract input_ids, attention_mask, and audio_values from the processed inputs
-        input_ids = inputs["input_ids"].squeeze(0)
-        attention_mask = inputs["attention_mask"].squeeze(0)
-        audio_values = inputs["audio_values"].squeeze(0)
-        audio_token_start_idx = inputs["audio_token_start_idx"].squeeze(0)
-        audio_token_len = inputs["audio_token_len"].squeeze(0)
+        input_ids = inputs["input_ids"].squeeze_(0)
+        inputs["attention_mask"].squeeze_(0)
+        if "audio_values" in inputs:
+            inputs["audio_values"].squeeze_(0)
+            inputs["audio_token_start_idx"].squeeze_(0)
+            inputs["audio_token_len"].squeeze_(0)
 
         # No need to shift the labels as the model does it internally
         labels = input_ids.clone()
@@ -258,10 +259,7 @@ class UltravoxDataproc(datasets.Dataproc):
             labels[:input_text_len] = -100
 
         return {
-            "input_ids": input_ids,
-            "attention_mask": attention_mask,
-            "audio_values": audio_values,
+            **inputs,
+            # input_ids, attention_mask, audio_values, audio_token_start_idx, audio_token_len
             "labels": labels,
-            "audio_token_start_idx": audio_token_start_idx,
-            "audio_token_len": audio_token_len,
         }

--- a/ultravox/tools/gradio_demo.py
+++ b/ultravox/tools/gradio_demo.py
@@ -16,7 +16,7 @@ class DemoConfig:
     #    runs/llama2_asr_gigaspeech/checkpoint-1000/
     #    wandb://fixie/ultravox/model-llama2_asr_gigaspeech:v0
     model_path: str = "fixie-ai/ultravox"
-    default_prompt: str = "Transcribe <|audio|>"
+    default_prompt: str = "Transcribe\n<|audio|>"
 
 
 def main():
@@ -32,7 +32,7 @@ def main():
         gr.Audio(label="Audio", show_download_button=True),
     ]
     outputs = [gr.Textbox(label="Output")]
-    examples = [["Transcribe <|audio|>", "examples/test16.wav"]]
+    examples = [["Transcribe\n<|audio|>", "examples/test16.wav"]]
 
     gr.Interface(fn=wrapper, inputs=inputs, outputs=outputs, examples=examples).launch(
         share=True

--- a/ultravox/tools/infer_tool.py
+++ b/ultravox/tools/infer_tool.py
@@ -22,7 +22,7 @@ from ultravox.tools import infer_api
 # transcription of the audio content and the tool can perfom a WER calculation.
 # Remember to set the --asr flag when using an ASR input.
 DEFAULT_PROMPT = "Listen to <|audio|> and respond to it"
-DEFAULT_ASR_PROMPT = "Transcribe <|audio|>"
+DEFAULT_ASR_PROMPT = "Transcribe\n<|audio|>"
 
 
 @dataclasses.dataclass

--- a/ultravox/training/config_base.py
+++ b/ultravox/training/config_base.py
@@ -14,6 +14,7 @@ from ultravox.model import ultravox_config
 @dataclasses.dataclass
 class TrainConfig:
     data_sets: List[str]
+    val_sets: List[str]
     # language model to use
     text_model: str
     # audio encoder model to use

--- a/ultravox/training/configs/meta_config.yaml
+++ b/ultravox/training/configs/meta_config.yaml
@@ -2,7 +2,7 @@ text_model: "meta-llama/Meta-Llama-3-8B-Instruct"
 audio_model: "facebook/wav2vec2-base-960h"
 
 data_sets: ["gigaspeech"]
-val_sets: ["heysquad_human", "anyinstruct", "gigaspeech", "soda"]
+val_sets: ["heysquad_human", "anyinstruct", "soda", "commonvoice", "commonvoice:zh-CN", "commonvoice:es"]
 repeat_data: True
 
 train_on_inputs: False

--- a/ultravox/training/configs/meta_config.yaml
+++ b/ultravox/training/configs/meta_config.yaml
@@ -9,7 +9,7 @@ train_on_inputs: False
 shuffle_data: True
 max_audio_duration_secs: 16
 
-val_num_samples: 128
+val_num_samples: 64
 val_steps: 1000
 eval_num_samples: 256
 eval_max_new_tokens: 32

--- a/ultravox/training/configs/meta_config.yaml
+++ b/ultravox/training/configs/meta_config.yaml
@@ -2,6 +2,7 @@ text_model: "meta-llama/Meta-Llama-3-8B-Instruct"
 audio_model: "facebook/wav2vec2-base-960h"
 
 data_sets: ["gigaspeech"]
+val_sets: ["heysquad_human", "anyinstruct", "librispeech", "soda"]
 repeat_data: True
 
 train_on_inputs: False
@@ -9,7 +10,7 @@ shuffle_data: True
 max_audio_duration_secs: 16
 
 val_num_samples: 128
-val_steps: 500
+val_steps: 1000
 eval_num_samples: 256
 eval_max_new_tokens: 32
 eval_num_procs: 16

--- a/ultravox/training/configs/meta_config.yaml
+++ b/ultravox/training/configs/meta_config.yaml
@@ -2,7 +2,7 @@ text_model: "meta-llama/Meta-Llama-3-8B-Instruct"
 audio_model: "facebook/wav2vec2-base-960h"
 
 data_sets: ["gigaspeech"]
-val_sets: ["heysquad_human", "anyinstruct", "librispeech", "soda"]
+val_sets: ["heysquad_human", "anyinstruct", "gigaspeech", "soda"]
 repeat_data: True
 
 train_on_inputs: False

--- a/ultravox/training/configs/meta_config.yaml
+++ b/ultravox/training/configs/meta_config.yaml
@@ -2,7 +2,7 @@ text_model: "meta-llama/Meta-Llama-3-8B-Instruct"
 audio_model: "facebook/wav2vec2-base-960h"
 
 data_sets: ["gigaspeech"]
-val_sets: ["heysquad_human", "anyinstruct", "soda", "commonvoice", "commonvoice:zh-CN", "commonvoice:es"]
+val_sets: ["heysquad_human", "anyinstruct", "soda", "peoplespeech"]
 repeat_data: True
 
 train_on_inputs: False

--- a/ultravox/training/train.py
+++ b/ultravox/training/train.py
@@ -29,7 +29,7 @@ from ultravox.training import config_base
 from ultravox.training import ddp_utils
 from ultravox.training import evaluation
 
-INPUT_EXAMPLE = {"text": "Transcribe <|audio|>", "audio": b"\x00\x00" * 16000}
+INPUT_EXAMPLE = {"text": "Transcribe\n<|audio|>", "audio": b"\x00\x00" * 16000}
 OUTPUT_EXAMPLE = {"text": "Hello, world!"}
 
 

--- a/ultravox/training/train.py
+++ b/ultravox/training/train.py
@@ -163,7 +163,7 @@ def main() -> None:
     train_dataset: data.IterableDataset
     val_datasets: data.IterableDataset
     val_sets = dict(
-        [("train", args.data_sets)]
+        [("matchtrain", args.data_sets)]
         + [(x, [x]) for x in args.val_sets]
         + [(f"text_{x}", [x]) for x in args.val_sets]  # TODO: include ASR datasets?
     )
@@ -200,7 +200,11 @@ def main() -> None:
                 train_on_inputs=args.train_on_inputs,
                 repeat_data=args.repeat_data,
                 processor=processor,
-                num_samples=args.val_num_samples,
+                num_samples=(
+                    args.val_num_samples
+                    if k == "matchtrain"
+                    else args.val_num_samples // 2
+                ),
                 data_args=val_ds_args_text if k.startswith("text_") else val_ds_args,
             )
             for k in val_sets

--- a/ultravox/training/train.py
+++ b/ultravox/training/train.py
@@ -203,11 +203,7 @@ def main() -> None:
                 train_on_inputs=args.train_on_inputs,
                 repeat_data=args.repeat_data,
                 processor=processor,
-                num_samples=(
-                    args.val_num_samples
-                    if k == "matchtrain"
-                    else args.val_num_samples // 2
-                ),
+                num_samples=args.val_num_samples,
                 data_args=val_ds_args_text if k.startswith("text_") else val_ds_args,
             )
             for k in val_sets

--- a/ultravox/training/train.py
+++ b/ultravox/training/train.py
@@ -157,7 +157,6 @@ def main() -> None:
         f"Using dtype and device (world_size): {dtype}, {device} ({world_size})"
     )
     model.to(device=device, dtype=dtype)
-    # TODO: check if the whole model can now be moved to dtype instead
 
     # Prepare dataset, subsetting if needed
     train_dataset: data.IterableDataset

--- a/ultravox/training/train.py
+++ b/ultravox/training/train.py
@@ -6,7 +6,7 @@ import os
 import re
 import sys
 from datetime import datetime
-from typing import List, Optional
+from typing import Dict, List, Optional
 
 import datasets as hf_datasets
 import safetensors.torch
@@ -161,7 +161,7 @@ def main() -> None:
 
     # Prepare dataset, subsetting if needed
     train_dataset: data.IterableDataset
-    val_datasets: data.IterableDataset
+    val_datasets: Dict[str, data.IterableDataset]
     val_sets = dict(
         [("matchtrain", args.data_sets)]
         + [(x, [x]) for x in args.val_sets]

--- a/ultravox/training/train.py
+++ b/ultravox/training/train.py
@@ -162,10 +162,13 @@ def main() -> None:
     # Prepare dataset, subsetting if needed
     train_dataset: data.IterableDataset
     val_datasets: Dict[str, data.IterableDataset]
+    # We use multiple validation sets here so that the results are comparable even when training set changes
+    # To make sure we can compare training and validation loss (e.g. for fine-tuning), we keep a special set
+    # called "matchtrain" that uses the same data as the training set.
     val_sets = dict(
         [("matchtrain", args.data_sets)]
         + [(x, [x]) for x in args.val_sets]
-        + [(f"text_{x}", [x]) for x in args.val_sets]  # TODO: include ASR datasets?
+        + [(f"text_{x}", [x]) for x in args.val_sets]
     )
     if is_master:
         train_dataset = prepare_dataset(


### PR DESCRIPTION
This PR separates validation data_sets from training data_sets and adds separate evaluations for the following datasets both in the audio and text-only modes: `["heysquad_human", "anyinstruct", "soda", "peoplespeech"]`

Example perplexity/loss curves:
![image](https://github.com/user-attachments/assets/074450b6-bf02-4255-81bf-b3717a7140b3)