### PR TITLE
Make so infer_tools works with a single arg for filename

### DIFF
--- a/ultravox/tools/infer_tool.py
+++ b/ultravox/tools/infer_tool.py
@@ -95,8 +95,9 @@ def run_tui(
     if index >= 0:
         print(f"--- Sample {index} ---")
     messages = sample.messages
+    question_message = messages[-2] if len(messages) > 1 else messages[-1]
     transcript = f' ["{sample.audio_transcript}"]' if sample.audio_transcript else ""
-    print(f"Q: {messages[-2]['content']}{transcript}")
+    print(f"Q: {question_message['content']}{transcript}")
     print(f"A: ", end="")
     start_time = time.time()
     first_token_time = None
@@ -139,7 +140,7 @@ def run_tui(
             assert args.data_sets
             ds_name = args.data_sets[0]
             eval_sample = eval_types.Sample(
-                sample.audio_transcript or sample.messages[-2]["content"],
+                sample.audio_transcript or question_message["content"],
                 expected_answer=expected_response,
                 generated_answer=text,
             )


### PR DESCRIPTION
Previous to [this change](https://github.com/fixie-ai/ultravox/pull/35), it would be possible to say:

```
just infer -f path/to/file.wave
```
or 
```
just infer -f path/to/file.wav --prompt "some prompt"
```

But that broke. 

I have no idea if this is the right fix or not. Happy to run any local tests to verify. 