### PR TITLE
HF Model loading fixes

### DIFF
--- a/ultravox/model/ultravox_model.py
+++ b/ultravox/model/ultravox_model.py
@@ -33,6 +33,8 @@ class UltravoxModel(transformers.LlamaPreTrainedModel):
     config_class = UltravoxConfig
     config: UltravoxConfig  # for type hinting
     _no_split_modules = ["Wav2Vec2Model", "WhisperEncoder", "LlamaDecoderLayer"]
+    _keys_to_ignore_on_load_missing = ["audio_tower.*"]
+    _keys_to_ignore_on_load_unexpected = ["audio_tower.*", "language_model.*"]
 
     def __init__(self, config: UltravoxConfig):
         super().__init__(config)

--- a/ultravox/model/ultravox_model.py
+++ b/ultravox/model/ultravox_model.py
@@ -33,8 +33,14 @@ class UltravoxModel(transformers.LlamaPreTrainedModel):
     config_class = UltravoxConfig
     config: UltravoxConfig  # for type hinting
     _no_split_modules = ["Wav2Vec2Model", "WhisperEncoder", "LlamaDecoderLayer"]
-    _keys_to_ignore_on_load_missing = ["audio_tower.*"]
+    # We minimize the weights in state_dict in order to reduce the size of the checkpoint
+    # The issue is that load_pretrained() uses state_dict() keys to know what keys are expected
+    # As such we have to tell is to ignore some keys that are not always in the model
     _keys_to_ignore_on_load_unexpected = ["audio_tower.*", "language_model.*"]
+    # Usually we load encoder weights from a pretrained model, so we don't want to load the decoder weights
+    # Technically we never hit this issue because these keys are already removed from state_dict() however,
+    # but there's no harm in keeping it here for when we change that behavior.
+    _keys_to_ignore_on_load_missing = ["audio_tower.*"]
 
     def __init__(self, config: UltravoxConfig):
         super().__init__(config)


### PR DESCRIPTION
This PR fixes the following:
1. gets rid of the unexpected weights warnings
1. makes HF model loading faster by skipping random initialization

Example of the unexpected weights warning that this PR is supposed to resolve:
```
Some weights of the model checkpoint at fixie-ai/ultravox_dev were not used when initializing UltravoxModel: ['language_model.lm_head.weight', 'language_model.model.embed_tokens.weight', 'language_model.model.layers.0.input_layernorm.weight',

...

- This IS expected if you are initializing UltravoxModel from the checkpoint of a model trained on another task or with another architecture (e.g. initializing a BertForSequenceClassification model from a BertForPreTraining model).
- This IS NOT expected if you are initializing UltravoxModel from the checkpoint of a model that you expect to be exactly identical (initializing a BertForSequenceClassification model from a BertForSequenceClassification model).
```