### PR TITLE
Separate files for eval logs

### DIFF
--- a/ultravox/training/evaluation.py
+++ b/ultravox/training/evaluation.py
@@ -1,8 +1,8 @@
 import concurrent.futures
 import dataclasses
 import functools
-import os
 import json
+import os
 from typing import List, Optional
 
 import numpy as np

--- a/ultravox/training/train.py
+++ b/ultravox/training/train.py
@@ -304,7 +304,7 @@ def main() -> None:
             num_procs=args.eval_num_procs,
             num_samples=args.eval_num_samples,
             max_new_tokens=args.eval_max_new_tokens,
-            log_dir=wandb.run.dir if wandb.run is not None else str(args.logs_dir),
+            log_dir=wandb.run.dir if wandb.run else str(args.logs_dir),
         )
         if is_master:
             trainer.log(metrics)

--- a/ultravox/training/train.py
+++ b/ultravox/training/train.py
@@ -14,11 +14,11 @@ import simple_parsing
 import torch
 import torch.distributed
 import transformers
+import wandb
 import wandb.sdk
 from torch.distributed.elastic.multiprocessing.errors import record
 from torch.utils import data
 
-import wandb
 from ultravox.data import datasets
 from ultravox.inference import infer
 from ultravox.model import data_processing

--- a/ultravox/training/train.py
+++ b/ultravox/training/train.py
@@ -14,10 +14,11 @@ import simple_parsing
 import torch
 import torch.distributed
 import transformers
-import wandb
+import wandb.sdk
 from torch.distributed.elastic.multiprocessing.errors import record
 from torch.utils import data
 
+import wandb
 from ultravox.data import datasets
 from ultravox.inference import infer
 from ultravox.model import data_processing
@@ -131,6 +132,7 @@ def main() -> None:
             name=args.exp_name,
             dir="runs",
             tags=args.run_tags,
+            save_code=True,
         )
 
     if args.model_load_dir:
@@ -302,7 +304,7 @@ def main() -> None:
             num_procs=args.eval_num_procs,
             num_samples=args.eval_num_samples,
             max_new_tokens=args.eval_max_new_tokens,
-            verbose=True,
+            log_dir=wandb.run.dir if wandb.run is not None else str(args.logs_dir),
         )
         if is_master:
             trainer.log(metrics)


### PR DESCRIPTION
Removes eval sample logs from the main log path to declutter it and they're each written to their own specific file so that they are easier to inspect.

The new files will be stored under the `Files` tab in W&B in a separate `evals` directory.

![image](https://github.com/user-attachments/assets/e37a0407-0250-43d8-8c4f-cd1e47265f3a)
![image](https://github.com/user-attachments/assets/ef3f1e00-7fc3-4c14-991f-00b5eec34208)
![image](https://github.com/user-attachments/assets/b7dcd59e-a864-4a34-b568-ccbe15dc07a3)
![image](https://github.com/user-attachments/assets/630e549f-ec87-463d-8248-b85454ae8976)