### PR TITLE
add generic dataset

### DIFF
--- a/mcloud.yaml
+++ b/mcloud.yaml
@@ -13,6 +13,5 @@ command: >-
   cd ultravox && poetry install --no-dev && poetry run torchrun --nproc_per_node=8 -m ultravox.training.train $TRAIN_ARGS
 env_variables:
   MLFLOW_TRACKING_URI: databricks
-  # temperary for training verfication
-  UV_BRANCH: zhuang/add-generic-dataset
+  UV_BRANCH: main
   TRAIN_ARGS: --config_path ultravox/training/configs/llama3_whisper_kd.yaml

--- a/mcloud.yaml
+++ b/mcloud.yaml
@@ -14,5 +14,5 @@ command: >-
 env_variables:
   MLFLOW_TRACKING_URI: databricks
   # temperary for training verfication
-  UV_BRANCH: main
+  UV_BRANCH: zhuang/add-generic-dataset
   TRAIN_ARGS: --config_path ultravox/training/configs/llama3_whisper_kd.yaml

--- a/mcloud.yaml
+++ b/mcloud.yaml
@@ -13,6 +13,5 @@ command: >-
   cd ultravox && poetry install --no-dev && poetry run torchrun --nproc_per_node=8 -m ultravox.training.train $TRAIN_ARGS
 env_variables:
   MLFLOW_TRACKING_URI: databricks
-  # temporary branch for running experiments
-  UV_BRANCH: zhuang/add-generic-dataset
+  UV_BRANCH: main
   TRAIN_ARGS: --config_path ultravox/training/configs/llama3_whisper_kd.yaml

--- a/mcloud.yaml
+++ b/mcloud.yaml
@@ -13,5 +13,6 @@ command: >-
   cd ultravox && poetry install --no-dev && poetry run torchrun --nproc_per_node=8 -m ultravox.training.train $TRAIN_ARGS
 env_variables:
   MLFLOW_TRACKING_URI: databricks
-  UV_BRANCH: main
+  # temporary branch for running experiments
+  UV_BRANCH: zhuang/add-generic-dataset
   TRAIN_ARGS: --config_path ultravox/training/configs/llama3_whisper_kd.yaml

--- a/ultravox/data/dataset_config.py
+++ b/ultravox/data/dataset_config.py
@@ -1,0 +1,21 @@
+import dataclasses
+from typing import List, Optional
+
+from pydantic import BaseModel
+
+
+class DataDictConfig(BaseModel):
+    # Path to the dataset, or huggingface dataset id
+    path: str
+    # Name of the dataset, or huggingface dataset config/subset
+    name: Optional[str] = None
+    splits: List[str] = dataclasses.field(default_factory=list)
+    num_samples: Optional[int] = None
+    streaming: bool = True
+    user_template: str = "<|audio|>"
+    assistant_template: str = "{{text}}"
+    transcript_template: str = "{{text}}"
+
+    def __post_init__(self):
+        if not self.splits:
+            raise ValueError("At least one split must be provided")

--- a/ultravox/data/datasets.py
+++ b/ultravox/data/datasets.py
@@ -20,8 +20,8 @@ import torch.nn.functional as F
 import transformers
 from torch.utils import data
 
+from ultravox.data import dataset_config
 from ultravox.data import text_proc
-from ultravox.training import config_base
 
 SAMPLE_RATE = 16000
 
@@ -975,7 +975,7 @@ class SodaDataset(VoiceDataset):
 
 class GenericVoiceDataset(VoiceDataset):
     def __init__(
-        self, args: VoiceDatasetArgs, config: config_base.DataDictConfig
+        self, args: VoiceDatasetArgs, config: dataset_config.DataDictConfig
     ) -> None:
         super().__init__(args)
 
@@ -1052,7 +1052,7 @@ def create_dataset(name: str, args: VoiceDatasetArgs) -> data.IterableDataset:
         "soda": SodaDataset,
         "dummy": LibriSpeechDummyDataset,
     }
-    if isinstance(name, config_base.DataDictConfig):
+    if isinstance(name, dataset_config.DataDictConfig):
         return GenericVoiceDataset(args, name)
     else:
         name, *ext = name.split(":")

--- a/ultravox/training/config_base.py
+++ b/ultravox/training/config_base.py
@@ -38,15 +38,21 @@ class TrainConfig:
     # audio encoder model to use
     audio_model: str
 
-    do_train: bool = True
-    do_eval: bool = True
-
+    # The data_dicts field complements data_sets, allowing for the inclusion of
+    # new datasets in the config.
+    #
     # Due to simple_parsing's lack of support for containers of dataclass types,
     # we first parse the data_dicts as a list of dictionaries. After parsing,
     # we convert these dictionaries to DataDictConfig objects using Pydantic
     # to enforce type constraints and validation, in the __post_init__ method.
     data_dicts: Optional[List[Dict[str, Any]]] = None
 
+    do_train: bool = True
+    do_eval: bool = True
+
+    # In InterleaveDataset, if one dataset runs out, should we repeat it to keep
+    # the ratio of samples from each dataset fixed?
+    repeat_data: bool = False
     data_dir: Optional[str] = None
     mds: bool = False
     num_samples: Optional[int] = None

--- a/ultravox/training/configs/llama3_whisper_kd.yaml
+++ b/ultravox/training/configs/llama3_whisper_kd.yaml
@@ -20,4 +20,22 @@ val_sets: ["anyinstruct", "soda", "peoplespeech"]
 batch_size: 4
 max_steps: 1000
 
-data_sets: ["gigaspeech", "anyinstruct", "soda"]
+data_sets: []
+data_dicts:
+  - path: "fixie-ai/librispeech_asr"
+    name: "clean"
+    splits:
+      - "train.100"
+      - "train.360"
+    user_template: "Continue the following text using less than 50 words:\n\n<|audio|>"
+    assistant_template: "{{ continuation }}"
+    transcript_template: "{{ text }}"
+    num_samples: 100_000
+  - path: "fixie-ai/librispeech_asr"
+    name: "other"
+    splits:
+      - "train.500"
+    user_template: "Continue the following text using less than 50 words:\n\n<|audio|>"
+    assistant_template: "{{ continuation }}"
+    transcript_template: "{{ text }}"
+    num_samples: 100_000


### PR DESCRIPTION
Add GenericVoiceDataset to support new datasets via yaml config, e.g., 

```
data_dicts:
  - path: "fixie-ai/librispeech_asr"
    name: "clean"
    splits:
      - "train.100"
      - "train.360"
    user_template: "Continue the following text using less than 50 words:\n\n<|audio|>"
    assistant_template: "{{ continuation }}"
    transcript_template: "{{ text }}"
    num_samples: 100_000
  - path: "fixie-ai/librispeech_asr"
    name: "other"
    splits:
      - "train.500"
    user_template: "Continue the following text using less than 50 words:\n\n<|audio|>"
    assistant_template: "{{ continuation }}"
    transcript_template: "{{ text }}"
    num_samples: 100_000
```

See ultravox.training.configs.llama3_whisper_kd.yaml for example experiment configuration. 