### PR TITLE
Fix TypeError: non-default argument 'template' follows default argument, and filter out audio

### DIFF
--- a/ultravox/tools/ds_tool/continuation.jinja
+++ b/ultravox/tools/ds_tool/continuation.jinja
@@ -1,3 +1,3 @@
 Continue the following text using less than 50 words:
 
-{{ text_proc.format_asr_text(sentence) }}
+{{ text_proc.format_asr_text(text) }}

--- a/ultravox/tools/ds_tool/continuation.jinja
+++ b/ultravox/tools/ds_tool/continuation.jinja
@@ -1,3 +1,3 @@
 Continue the following text using less than 50 words:
 
-{{ text_proc.format_asr_text(text) }}
+{{ text_proc.format_asr_text(sentence) }}

--- a/ultravox/tools/ds_tool/ds_tool.py
+++ b/ultravox/tools/ds_tool/ds_tool.py
@@ -113,7 +113,9 @@ class TextGenerationTask:
     def _map_sample(self, sample):
         # e.g., {{ text }} or {{ text_proc.format_asr_text(text) }}
         try:
-            filtered_sample = {"sentence": sample["sentence"]}
+            # We need to filter out the audio before the sample is passed into the jinja template
+            # or it will get loaded into memory and spike usage.
+            filtered_sample = {k: v for k, v in sample.items() if k != "audio"}
             rendered = jinja2.Template(
                 self.template, undefined=jinja2.StrictUndefined
             ).render(**filtered_sample, json_dump=json.dumps, text_proc=text_proc)

--- a/ultravox/tools/ds_tool/ds_tool.py
+++ b/ultravox/tools/ds_tool/ds_tool.py
@@ -19,9 +19,8 @@ chat_client: caching.CachingChatWrapper
 
 @dataclasses.dataclass
 class TtsTask:
-    template: str = simple_parsing.field(alias="-T")
     implementation: str = simple_parsing.field(default="azure", alias="-i")
-    # Column name containing the text to convert to audio. It can be a Jinja variable expression.
+    template: str = simple_parsing.field(default=None, alias="-T")
     json_mode: bool = simple_parsing.field(default=False, alias="-j")
     audio_column_name: Optional[str] = simple_parsing.field(default=None, alias="-a")
     voice: Optional[str] = simple_parsing.field(default=None, alias="-V")

--- a/ultravox/tools/ds_tool/ds_tool.py
+++ b/ultravox/tools/ds_tool/ds_tool.py
@@ -19,8 +19,9 @@ chat_client: caching.CachingChatWrapper
 
 @dataclasses.dataclass
 class TtsTask:
+    # Jinja template for the text that needs to be converted to audio
+    template: str = simple_parsing.field(alias="-T")
     implementation: str = simple_parsing.field(default="azure", alias="-i")
-    template: str = simple_parsing.field(default=None, alias="-T")
     json_mode: bool = simple_parsing.field(default=False, alias="-j")
     audio_column_name: Optional[str] = simple_parsing.field(default=None, alias="-a")
     voice: Optional[str] = simple_parsing.field(default=None, alias="-V")

--- a/ultravox/tools/ds_tool/ds_tool.py
+++ b/ultravox/tools/ds_tool/ds_tool.py
@@ -21,7 +21,7 @@ chat_client: caching.CachingChatWrapper
 class TtsTask:
     implementation: str = simple_parsing.field(default="azure", alias="-i")
     # Column name containing the text to convert to audio. It can be a Jinja variable expression.
-    template: str = simple_parsing.field(alias="-T")
+    template: str = simple_parsing.field(default="continuation.jinja", alias="-T")
     json_mode: bool = simple_parsing.field(default=False, alias="-j")
     audio_column_name: Optional[str] = simple_parsing.field(default=None, alias="-a")
     voice: Optional[str] = simple_parsing.field(default=None, alias="-V")

--- a/ultravox/tools/ds_tool/ds_tool.py
+++ b/ultravox/tools/ds_tool/ds_tool.py
@@ -111,6 +111,7 @@ class TextGenerationTask:
         )
 
     def _map_sample(self, sample):
+        # using a Jinja template for some added flexibility, template can include variables and functions
         # e.g., {{ text }} or {{ text_proc.format_asr_text(text) }}
         try:
             # We need to filter out the audio before the sample is passed into the jinja template

--- a/ultravox/tools/ds_tool/ds_tool.py
+++ b/ultravox/tools/ds_tool/ds_tool.py
@@ -19,9 +19,9 @@ chat_client: caching.CachingChatWrapper
 
 @dataclasses.dataclass
 class TtsTask:
+    template: str = simple_parsing.field(alias="-T")
     implementation: str = simple_parsing.field(default="azure", alias="-i")
     # Column name containing the text to convert to audio. It can be a Jinja variable expression.
-    template: str = simple_parsing.field(default="continuation.jinja", alias="-T")
     json_mode: bool = simple_parsing.field(default=False, alias="-j")
     audio_column_name: Optional[str] = simple_parsing.field(default=None, alias="-a")
     voice: Optional[str] = simple_parsing.field(default=None, alias="-V")

--- a/ultravox/tools/ds_tool/ds_tool.py
+++ b/ultravox/tools/ds_tool/ds_tool.py
@@ -111,12 +111,12 @@ class TextGenerationTask:
         )
 
     def _map_sample(self, sample):
-        # using a Jinja template for some added flexibility, template can include variables and functions
         # e.g., {{ text }} or {{ text_proc.format_asr_text(text) }}
         try:
+            filtered_sample = {"sentence": sample["sentence"]}
             rendered = jinja2.Template(
                 self.template, undefined=jinja2.StrictUndefined
-            ).render(**sample, json_dump=json.dumps, text_proc=text_proc)
+            ).render(**filtered_sample, json_dump=json.dumps, text_proc=text_proc)
         except jinja2.TemplateError as e:
             print(f"Error rendering template: {e}")
             print(f"template: {self.template}")

--- a/ultravox/tools/ds_tool/ds_tool.py
+++ b/ultravox/tools/ds_tool/ds_tool.py
@@ -111,7 +111,7 @@ class TextGenerationTask:
     ) -> datasets.Dataset:
         print(f'Generating "{self.new_column_name}" with template:\n{self.template}')
         return ds_split.map(
-            lambda sample: self._map_sample(sample, exclude_fields),
+            lambda sample: self._map_sample(sample, set(exclude_fields)),
             num_proc=num_proc,
             writer_batch_size=writer_batch_size,
         )
@@ -131,7 +131,7 @@ class TextGenerationTask:
         except jinja2.TemplateError as e:
             print(f"Error rendering template: {e}")
             print(f"template: {self.template}")
-            print(f"sample keys: {list(sample.keys())}")
+            print(f"sample keys: {list(filtered_sample.keys())}")
             raise ValueError(
                 f"Template rendering failed. Make sure all keys in the template exist in the sample."
             ) from e
@@ -175,9 +175,7 @@ class DatasetToolArgs:
     num_samples: Optional[int] = simple_parsing.field(default=None, alias="-n")
     num_workers: int = simple_parsing.field(default=16, alias="-w")
     writer_batch_size: int = simple_parsing.field(default=1000)
-    exclude_fields: Optional[List[str]] = simple_parsing.field(
-        default_factory=lambda: ["audio"]
-    )
+    exclude_fields: List[str] = simple_parsing.field(default_factory=lambda: ["audio"])
 
     # HF destination dataset parameters
     upload_name: Optional[str] = simple_parsing.field(default=None, alias="-u")

--- a/ultravox/tools/ds_tool/ds_tool.py
+++ b/ultravox/tools/ds_tool/ds_tool.py
@@ -42,7 +42,11 @@ class TtsTask:
                 self.template = template_file.read()
 
     def map_split(
-        self, ds_split: datasets.Dataset, num_proc: int, writer_batch_size: int
+        self,
+        ds_split: datasets.Dataset,
+        num_proc: int,
+        writer_batch_size: int,
+        excluded_fields: List[str],
     ) -> datasets.Dataset:
         print(f'TTS mapping "{self.template}" to "{self.audio_column_name}"...')
         ds_split = ds_split.map(


### PR DESCRIPTION
1. Fixes TypeError: non-default argument 'template' follows default argument
2. Filters out audio before passed into jinja template to prevent memory spikes when using ds_tool.py