### PR TITLE
Add option to force push LLM weights

### DIFF
--- a/ultravox/tools/push_to_hub.py
+++ b/ultravox/tools/push_to_hub.py
@@ -27,6 +27,8 @@ class UploadToHubArgs:
     data_type: Optional[str] = None
     # Public or private (default)
     private: bool = True
+    # Push LLM weights even if they are not fine-tuned
+    force_push_llm_weights: bool = True
 
 
 def main(args: UploadToHubArgs):
@@ -37,6 +39,11 @@ def main(args: UploadToHubArgs):
         device=args.device,
         data_type=args.data_type,
     )
+    if args.force_push_llm_weights and hasattr(
+        inference.model, "_add_language_model_weights_to_keep"
+    ):
+        inference.model._add_language_model_weights_to_keep()
+
     pipe = ultravox_pipeline.UltravoxPipeline(
         model=inference.model,
         tokenizer=inference.tokenizer,


### PR DESCRIPTION
The vLLM code couldn't load the new [`ultravox-dev`](https://huggingface.co/fixie-ai/ultravox-dev) weights since the LLM weights weren't included. So to make things easier this PR allows for force pushing LLM weights.

A better way to solve this would've been to update vLLM, but for the time being I think this is a simpler and less bug-prone approach.

The model weights were also updated with the following command:
`poetry run python -m ultravox.tools.push_to_hub -m wandb://fixie/ultravox/model-zhuang.2024-07-15-ultravox.blsp-kd-4e:v5 -u fixie-ai/ultravox-dev --force_push_llm_weights`