### PR TITLE
Live reload for Gradio demo

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -55,7 +55,7 @@ mds *FLAGS:
     poetry run python -m ultravox.tools.mds_tool {{FLAGS}}
 
 gradio *FLAGS:
-    poetry run python -m ultravox.tools.gradio_demo {{FLAGS}}
+    poetry run gradio ultravox/tools/gradio_demo.py {{FLAGS}}
 
 run *FLAGS:
     poetry run mcli run -f mcloud.yaml --follow {{FLAGS}}

--- a/ultravox/inference/infer.py
+++ b/ultravox/inference/infer.py
@@ -190,7 +190,6 @@ class LocalInference(base.VoiceInference):
             do_sample=do_sample,
             max_new_tokens=max_new_tokens or MAX_NEW_TOKENS,
             temperature=temperature,
-            repetition_penalty=REPETITION_PENALTY,
             pad_token_id=self.tokenizer.eos_token_id,
             eos_token_id=terminators,
             streamer=streamer,

--- a/ultravox/inference/infer.py
+++ b/ultravox/inference/infer.py
@@ -60,7 +60,7 @@ class LocalInference(base.VoiceInference):
         audio_token_len: int,
         response_content: str,
     ) -> List[Dict[str, str]]:
-        messages = query_messages[:]
+        messages = copy.copy(query_messages)
         if audio_token_len > 0:
             user_content = messages[-1]["content"]
             if user_content.count("<|audio|>") != 1:

--- a/ultravox/inference/infer.py
+++ b/ultravox/inference/infer.py
@@ -14,8 +14,6 @@ from ultravox.model import ultravox_processing
 
 SAMPLE_RATE = 16000
 MAX_NEW_TOKENS = 1024
-# Without this penalty, the model tends to repeat itself.
-REPETITION_PENALTY = 1.1
 
 
 class LocalInference(base.VoiceInference):

--- a/ultravox/inference/infer.py
+++ b/ultravox/inference/infer.py
@@ -105,9 +105,8 @@ class LocalInference(base.VoiceInference):
         extended_sample = self._get_sample_with_past(sample)
         inputs = self._dataproc(extended_sample)
         input_tokens = inputs["input_ids"].shape[1]
-        decode_kwargs = {"skip_special_tokens": True}
         streamer = transformers.TextIteratorStreamer(
-            self.tokenizer, skip_prompt=True, decode_kwargs=decode_kwargs
+            self.tokenizer, skip_prompt=True, skip_special_tokens=True
         )
 
         def thunk(q: queue.Queue):

--- a/ultravox/inference/infer.py
+++ b/ultravox/inference/infer.py
@@ -146,7 +146,9 @@ class LocalInference(base.VoiceInference):
             )
             f.set_result(result)
 
-        future = futures.Future()
+        future: futures.Future[transformers.GenerateDecoderOnlyOutput] = (
+            futures.Future()
+        )
         thread = threading.Thread(target=thunk, args=(future,))
         thread.start()
         output_text = ""

--- a/ultravox/inference/infer.py
+++ b/ultravox/inference/infer.py
@@ -116,8 +116,8 @@ class LocalInference(base.VoiceInference):
             )
             q.put(result)
 
-        q = queue.Queue()
-        thread = threading.Thread(target=thunk, args=(q,))
+        result_queue: queue.Queue = queue.Queue()
+        thread = threading.Thread(target=thunk, args=(result_queue,))
         thread.start()
         output_text = ""
         output_token_len = 0
@@ -127,7 +127,7 @@ class LocalInference(base.VoiceInference):
                 output_token_len += 1
                 yield base.InferenceChunk(chunk)
         thread.join()
-        output = q.get()
+        output = result_queue.get()
         if self.conversation_mode:
             audio_token_len = inputs.get("audio_token_len", [0])[0]
             past_messages = self._build_past_messages(

--- a/ultravox/inference/utils.py
+++ b/ultravox/inference/utils.py
@@ -5,9 +5,7 @@ def default_device():
     return (
         "cuda"
         if torch.cuda.is_available()
-        else "mps"
-        if torch.backends.mps.is_available()
-        else "cpu"
+        else "mps" if torch.backends.mps.is_available() else "cpu"
     )
 
 
@@ -19,7 +17,5 @@ def get_dtype(data_type: str):
     return (
         torch.bfloat16
         if data_type == "bfloat16"
-        else torch.float16
-        if data_type == "float16"
-        else torch.float32
+        else torch.float16 if data_type == "float16" else torch.float32
     )

--- a/ultravox/inference/utils.py
+++ b/ultravox/inference/utils.py
@@ -5,8 +5,8 @@ def default_device():
     return (
         "cuda"
         if torch.cuda.is_available()
-        # until https://github.com/pytorch/pytorch/issues/77764 is resolved
-        # else "mps" if torch.backends.mps.is_available() else "cpu"
+        else "mps"
+        if torch.backends.mps.is_available()
         else "cpu"
     )
 
@@ -19,5 +19,7 @@ def get_dtype(data_type: str):
     return (
         torch.bfloat16
         if data_type == "bfloat16"
-        else torch.float16 if data_type == "float16" else torch.float32
+        else torch.float16
+        if data_type == "float16"
+        else torch.float32
     )

--- a/ultravox/tools/gradio_demo.py
+++ b/ultravox/tools/gradio_demo.py
@@ -44,10 +44,12 @@ def add_text(chatbot: gr.Chatbot, text: str) -> gr.Chatbot:
     return chatbot + [[text, None]], ""
 
 
-def add_audio(chatbot: gr.Chatbot, audio: str) -> gr.Chatbot:
+def add_audio(chatbot: gr.Chatbot, audio: str, text: str) -> gr.Chatbot:
     # We want to keep the prompt (mixed audio/text instruction) as is in voice mode.
-    return chatbot + [[(audio,), None]]
-
+    if text:
+        return chatbot + [[text, None]] + [[(audio,), None]]
+    else:
+        return chatbot + [[(audio,), None]]
 
 def process_turn(
     chatbot: gr.Chatbot,

--- a/ultravox/tools/gradio_demo.py
+++ b/ultravox/tools/gradio_demo.py
@@ -5,6 +5,7 @@ import gradio as gr
 import simple_parsing
 
 from ultravox.data import datasets
+from ultravox.inference import base as infer_base
 from ultravox.inference import ultravox_infer
 
 demo_instruction: str = """Enter your prompt here (audio will be inserted at the end or at <|audio|>).
@@ -28,7 +29,7 @@ class DemoConfig:
     temperature: float = 0
 
 
-def main():
+if gr.NO_RELOAD:
     args = simple_parsing.parse(config_class=DemoConfig)
     inference = ultravox_infer.UltravoxInference(
         args.model_path,
@@ -37,116 +38,122 @@ def main():
         conversation_mode=True,
     )
 
-    def add_text(chatbot: gr.Chatbot, text: str) -> gr.Chatbot:
-        return chatbot + [(text, None)]
 
-    def add_audio(chatbot: gr.Chatbot, audio: str) -> gr.Chatbot:
-        return chatbot + [((audio,), None)]
+def add_text(chatbot: gr.Chatbot, text: str) -> gr.Chatbot:
+    # We set the prompt to "" in anticipation of the next prompt in text mode.
+    return chatbot + [[text, None]], ""
 
-    def process_turn(
-        chatbot: gr.Chatbot,
-        prompt: str,
-        audio: Optional[str] = None,
-        max_new_tokens: int = 200,
-        temperature: float = 0,
-    ):
-        # We want to keep the prompt (mixed audio/text instruction) as is in voice mode, but set it to "" in anticipation of new prompt in text mode.
-        prompt_to_return = prompt
-        if audio:
-            if "<|audio|>" not in prompt:
-                prompt += "<|audio|>"
-            sample = datasets.VoiceSample.from_prompt_and_file(prompt, audio)
-        else:
-            sample = datasets.VoiceSample.from_prompt(prompt)
-            prompt_to_return = ""
 
-        if len(sample.messages) != 1:
-            raise ValueError(
-                f"Expected exactly 1 message in sample but got {len(sample.messages)}"
+def add_audio(chatbot: gr.Chatbot, audio: str) -> gr.Chatbot:
+    # We want to keep the prompt (mixed audio/text instruction) as is in voice mode.
+    return chatbot + [[(audio,), None]]
+
+
+def process_turn(
+    chatbot: gr.Chatbot,
+    prompt: str,
+    audio: Optional[str] = None,
+    max_new_tokens: int = 200,
+    temperature: float = 0,
+):
+    if audio:
+        if "<|audio|>" not in prompt:
+            prompt += "<|audio|>"
+        sample = datasets.VoiceSample.from_prompt_and_file(prompt, audio)
+    else:
+        # Note that prompt will be "" here, since we cleared it in add_text.
+        # Instead, we can just get it from the chat history.
+        sample = datasets.VoiceSample.from_prompt(chatbot[-1][0])
+
+    if len(sample.messages) != 1:
+        raise ValueError(
+            f"Expected exactly 1 message in sample but got {len(sample.messages)}"
+        )
+
+    output = inference.infer_stream(
+        sample,
+        max_tokens=max_new_tokens,
+        temperature=temperature,
+    )
+    chatbot += [[None, ""]]
+    for chunk in output:
+        if isinstance(chunk, infer_base.InferenceChunk):
+            chatbot[-1][1] += chunk.text
+            yield chatbot
+
+
+def process_text(chatbot, prompt, max_new_tokens, temperature):
+    yield from process_turn(
+        chatbot, prompt, max_new_tokens=max_new_tokens, temperature=temperature
+    )
+
+
+def process_audio(chatbot, prompt, audio, max_new_tokens, temperature):
+    yield from process_turn(
+        chatbot,
+        prompt,
+        audio=audio,
+        max_new_tokens=max_new_tokens,
+        temperature=temperature,
+    )
+
+
+def gradio_reset():
+    inference.reset_conversation()
+    return [], "", None
+
+
+with gr.Blocks() as demo:
+    chatbot = gr.Chatbot(scale=10, height=1000)
+
+    with gr.Row():
+        with gr.Column(scale=1):
+            reset = gr.Button("Reset")
+            audio = gr.Audio(
+                label="🎤",
+                sources=["microphone"],
+                type="filepath",
+                visible=True,
             )
-
-        output = inference.infer(
-            sample,
-            max_tokens=max_new_tokens,
-            temperature=temperature,
-        )
-
-        chatbot = chatbot + [(None, output.text)]
-        return chatbot, gr.update(value=prompt_to_return)
-
-    def process_text(chatbot, prompt, max_new_tokens, temperature):
-        return process_turn(
-            chatbot, prompt, max_new_tokens=max_new_tokens, temperature=temperature
-        )
-
-    def process_audio(chatbot, prompt, audio, max_new_tokens, temperature):
-        return process_turn(
-            chatbot,
-            prompt,
-            audio=audio,
-            max_new_tokens=max_new_tokens,
-            temperature=temperature,
-        )
-
-    def gradio_reset():
-        inference.update_conversation()
-        return [], "", None
-
-    with gr.Blocks() as demo:
-        chatbot = gr.Chatbot(scale=10, height=1000)
-
-        with gr.Row():
-            with gr.Column(scale=1):
-                reset = gr.Button("Reset")
-                audio = gr.Audio(
-                    label="🎤",
-                    sources=["microphone"],
-                    type="filepath",
-                    visible=True,
-                )
-            with gr.Column(scale=8):
-                prompt = gr.Textbox(
-                    show_label=False,
-                    lines=5,
-                    placeholder=demo_instruction,
-                    value=args.default_prompt,
-                    container=True,
-                )
-            with gr.Column(scale=1):
-                max_new_tokens = gr.Slider(
-                    minimum=50,
-                    maximum=2000,
-                    value=args.max_new_tokens,
-                    step=10,
-                    interactive=True,
-                    label="max_new_tokens",
-                )
-                temperature = gr.Slider(
-                    minimum=0,
-                    maximum=5.0,
-                    value=args.temperature,
-                    step=0.1,
-                    interactive=True,
-                    label="temperature",
-                )
-
-        prompt.submit(add_text, [chatbot, prompt], [chatbot], queue=False).then(
-            process_text,
-            [chatbot, prompt, max_new_tokens, temperature],
-            [chatbot, prompt],
-            queue=False,
-        )
-        audio.stop_recording(add_audio, [chatbot, audio], [chatbot], queue=False).then(
-            process_audio,
-            [chatbot, prompt, audio, max_new_tokens, temperature],
-            [chatbot, prompt],
-            queue=False,
-        )
-        reset.click(gradio_reset, [], [chatbot, prompt, audio], queue=False)
-        demo.load(gradio_reset, [], [chatbot, prompt, audio], queue=False)
-
-    demo.launch(share=True)
+        with gr.Column(scale=8):
+            prompt = gr.Textbox(
+                show_label=False,
+                lines=5,
+                placeholder=demo_instruction,
+                value=args.default_prompt,
+                container=True,
+            )
+        with gr.Column(scale=1):
+            max_new_tokens = gr.Slider(
+                minimum=50,
+                maximum=2000,
+                value=args.max_new_tokens,
+                step=10,
+                interactive=True,
+                label="max_new_tokens",
+            )
+            temperature = gr.Slider(
+                minimum=0,
+                maximum=5.0,
+                value=args.temperature,
+                step=0.1,
+                interactive=True,
+                label="temperature",
+            )
+    prompt.submit(add_text, [chatbot, prompt], [chatbot, prompt], queue=False).then(
+        process_text,
+        [chatbot, prompt, max_new_tokens, temperature],
+        [chatbot],
+    )
+    audio.stop_recording(add_audio, [chatbot, audio], [chatbot], queue=False).then(
+        process_audio,
+        [chatbot, prompt, audio, max_new_tokens, temperature],
+        [chatbot],
+    )
+    reset.click(gradio_reset, [], [chatbot, prompt, audio], queue=False)
+    demo.load(gradio_reset, [], [chatbot, prompt, audio], queue=False)
 
 
 if __name__ == "__main__":
-    main()
+    demo.queue()
+    demo.launch(share=True)

--- a/ultravox/tools/gradio_demo.py
+++ b/ultravox/tools/gradio_demo.py
@@ -51,6 +51,7 @@ def add_audio(chatbot: gr.Chatbot, audio: str, text: str) -> gr.Chatbot:
     else:
         return chatbot + [[(audio,), None]]
 
+
 def process_turn(
     chatbot: gr.Chatbot,
     prompt: str,
@@ -147,7 +148,9 @@ with gr.Blocks() as demo:
         [chatbot, prompt, max_new_tokens, temperature],
         [chatbot],
     )
-    audio.stop_recording(add_audio, [chatbot, audio, prompt], [chatbot], queue=False).then(
+    audio.stop_recording(
+        add_audio, [chatbot, audio, prompt], [chatbot], queue=False
+    ).then(
         process_audio,
         [chatbot, prompt, audio, max_new_tokens, temperature],
         [chatbot],

--- a/ultravox/tools/gradio_demo.py
+++ b/ultravox/tools/gradio_demo.py
@@ -99,7 +99,7 @@ def process_audio(chatbot, prompt, audio, max_new_tokens, temperature):
 
 
 def gradio_reset():
-    inference.reset_conversation()
+    inference.update_conversation()
     return [], "", None
 
 

--- a/ultravox/tools/gradio_demo.py
+++ b/ultravox/tools/gradio_demo.py
@@ -46,10 +46,7 @@ def add_text(chatbot: gr.Chatbot, text: str) -> gr.Chatbot:
 
 def add_audio(chatbot: gr.Chatbot, audio: str, text: str) -> gr.Chatbot:
     # We want to keep the prompt (mixed audio/text instruction) as is in voice mode.
-    if text:
-        return chatbot + [[text, None]] + [[(audio,), None]]
-    else:
-        return chatbot + [[(audio,), None]]
+    return chatbot + ([[text, None]] if text else []) + [[(audio,), None]]
 
 
 def process_turn(

--- a/ultravox/tools/gradio_demo.py
+++ b/ultravox/tools/gradio_demo.py
@@ -6,9 +6,9 @@ import simple_parsing
 
 from ultravox.data import datasets
 from ultravox.inference import base as infer_base
-from ultravox.inference import ultravox_infer
+from ultravox.tools import gradio_helper
 
-demo_instruction: str = """Enter your prompt here (audio will be inserted at the end or at <|audio|>).
+DEMO_INSTRUCTION: str = """Enter your prompt here (audio will be inserted at the end or at <|audio|>).
 
 Text mode: Shift+Enter to submit.
 Voice mode: Click the recording button to start, then click again to stop and submit.
@@ -29,14 +29,11 @@ class DemoConfig:
     temperature: float = 0
 
 
-if gr.NO_RELOAD:
-    args = simple_parsing.parse(config_class=DemoConfig)
-    inference = ultravox_infer.UltravoxInference(
-        args.model_path,
-        device=args.device,
-        data_type=args.data_type,
-        conversation_mode=True,
-    )
+args = simple_parsing.parse(config_class=DemoConfig)
+# This script will get loaded from both the python runtime as well as gradio's reloader,
+# even when gr.NO_RELOAD is used. To avoid model re-init, we use a helper singleton
+# to manage the inference object.
+inference = gradio_helper.get_inference(args)
 
 
 def add_text(chatbot: gr.Chatbot, text: str) -> gr.Chatbot:
@@ -119,7 +116,7 @@ with gr.Blocks() as demo:
             prompt = gr.Textbox(
                 show_label=False,
                 lines=5,
-                placeholder=demo_instruction,
+                placeholder=DEMO_INSTRUCTION,
                 value=args.default_prompt,
                 container=True,
             )

--- a/ultravox/tools/gradio_demo.py
+++ b/ultravox/tools/gradio_demo.py
@@ -147,7 +147,7 @@ with gr.Blocks() as demo:
         [chatbot, prompt, max_new_tokens, temperature],
         [chatbot],
     )
-    audio.stop_recording(add_audio, [chatbot, audio], [chatbot], queue=False).then(
+    audio.stop_recording(add_audio, [chatbot, audio, prompt], [chatbot], queue=False).then(
         process_audio,
         [chatbot, prompt, audio, max_new_tokens, temperature],
         [chatbot],

--- a/ultravox/tools/gradio_helper.py
+++ b/ultravox/tools/gradio_helper.py
@@ -1,0 +1,17 @@
+from typing import Optional
+
+from ultravox.inference import ultravox_infer
+
+inference: Optional[ultravox_infer.UltravoxInference] = None
+
+
+def get_inference(args) -> ultravox_infer.UltravoxInference:
+    global inference
+    if not inference:
+        inference = ultravox_infer.UltravoxInference(
+            args.model_path,
+            device=args.device,
+            data_type=args.data_type,
+            conversation_mode=True,
+        )
+    return inference


### PR DESCRIPTION
Fixes #80 

Now, changes that you make during editing are reflected immediately in the demo. For this to work `demo` has to be a global object, so the `main` function has been removed (as recommended by gradio: https://www.gradio.app/guides/quickstart)

Also adds streaming of output tokens, using `infer_stream` and queueing.