### PR TITLE
Working AutoProcessor.from_pretrained

### DIFF
--- a/ultravox/model/ultravox_model.py
+++ b/ultravox/model/ultravox_model.py
@@ -501,6 +501,5 @@ UltravoxModel.register_for_auto_class()
 
 transformers.AutoConfig.register("ultravox", UltravoxConfig)
 transformers.AutoModel.register(UltravoxConfig, UltravoxModel)
-# transformers.AutoProcessor.register(UltravoxConfig, UltravoxProcessor)  # TODO: make processor work standalone
 
 transformers.activations.ACT2FN["swiglu"] = SwiGLU

--- a/ultravox/model/ultravox_processing.py
+++ b/ultravox/model/ultravox_processing.py
@@ -4,6 +4,8 @@ import numpy as np
 import torch
 import transformers
 
+from .ultravox_config import UltravoxConfig
+
 
 class UltravoxProcessor(transformers.ProcessorMixin):
     """
@@ -55,6 +57,29 @@ class UltravoxProcessor(transformers.ProcessorMixin):
             self.audio_token_replacement is not None
         ), "The tokenizer has no EOS token. Cannot recover."
         super().__init__(audio_processor=audio_processor, tokenizer=tokenizer)
+
+    @classmethod
+    def from_pretrained(cls, pretrained_model_name_or_path, **kwargs):
+        config: UltravoxConfig = transformers.AutoConfig.from_pretrained(
+            pretrained_model_name_or_path, **kwargs
+        )
+        audio_processor = transformers.AutoProcessor.from_pretrained(
+            config.audio_model_id
+            or config.audio_config._name_or_path
+            or "facebook/wav2vec2-base-960h"
+        )
+
+        tokenizer = transformers.AutoTokenizer.from_pretrained(
+            pretrained_model_name_or_path, **kwargs
+        )
+        tokenizer.padding_side = "left"
+        tokenizer.pad_token = tokenizer.eos_token
+
+        return cls(
+            audio_processor=audio_processor,
+            tokenizer=tokenizer,
+            stack_factor=config.stack_factor,
+        )
 
     def __call__(
         self,
@@ -175,3 +200,6 @@ class UltravoxProcessor(transformers.ProcessorMixin):
         tokenizer_input_names = self.tokenizer.model_input_names
         audio_processor_input_names = self.audio_processor.model_input_names
         return list(set(tokenizer_input_names + audio_processor_input_names))
+
+
+transformers.AutoProcessor.register(UltravoxConfig, UltravoxProcessor)


### PR DESCRIPTION
With this PR (assuming the code is updated on HF), we can call `transformers.AutoProcessor.from_pretrained('fixie-ai/ultravox-v0_3')` to get the processor (needed by @petersalas for the VLLM PR).