### PR TITLE
Use bfloat16 by default on MPS

### DIFF
--- a/ultravox/inference/utils.py
+++ b/ultravox/inference/utils.py
@@ -10,11 +10,11 @@ def default_device():
 
 
 def default_dtype():
-    # MPS got bfloat16 support in macOS Sonoma 14.
+    # macOS Sonoma 14 enabled bfloat16 on MPS.
     return (
         torch.bfloat16
         if torch.cuda.is_available() or torch.backends.mps.is_available()
-        else torch.float32
+        else torch.float16
     )
 
 

--- a/ultravox/inference/utils.py
+++ b/ultravox/inference/utils.py
@@ -10,7 +10,12 @@ def default_device():
 
 
 def default_dtype():
-    return torch.bfloat16 if torch.cuda.is_available() else torch.float32
+    # MPS got bfloat16 support in macOS Sonoma 14.
+    return (
+        torch.bfloat16
+        if torch.cuda.is_available() or torch.backends.mps.is_available()
+        else torch.float32
+    )
 
 
 def get_dtype(data_type: str):


### PR DESCRIPTION
Much faster than float32 and just as fast as float16, on both model loading and generation, thanks to support in macOS 14.

```
% time just infer -v --text_only --prompt count-to-10
poetry run python -m ultravox.tools.infer_tool -v --text_only --prompt count-to-10
Loading checkpoint shards: 100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 4/4 [00:14<00:00,  3.61s/it]
Q: count-to-10
A: 1, 2, 3, 4, 5, 6, 7, 8, 9, 10. [ttft: 3.56 s, tok: 10, tps: 2.86, tot: 7.06 s]
---
% time just infer -v --text_only --prompt count-to-10 --data_type float16
poetry run python -m ultravox.tools.infer_tool -v --text_only --prompt count-to-10 --data_type float16
Loading checkpoint shards: 100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 4/4 [00:06<00:00,  1.54s/it]
Q: count-to-10
A: 1, 2, 3, 4, 5, 6, 7, 8, 9, 10. [ttft: 2.31 s, tok: 10, tps: 4.32, tot: 4.62 s]
just infer -v --text_only --prompt count-to-10 --data_type float16  18.74s user 11.23s system 142% cpu 21.049 total
---
% time just infer -v --text_only --prompt count-to-10 --data_type bfloat16 
poetry run python -m ultravox.tools.infer_tool -v --text_only --prompt count-to-10 --data_type bfloat16
Loading checkpoint shards: 100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 4/4 [00:01<00:00,  3.11it/s]
Q: count-to-10
A: 1, 2, 3, 4, 5, 6, 7, 8, 9, 10. [ttft: 2.45 s, tok: 10, tps: 3.62, tot: 5.22 s]
just infer -v --text_only --prompt count-to-10 --data_type bfloat16  9.83s user 5.27s system 79% cpu 19.009 total
```