### PR TITLE
Change tokenizer padding_side to left for eval

### DIFF
--- a/ultravox/training/train.py
+++ b/ultravox/training/train.py
@@ -303,6 +303,8 @@ def main() -> None:
         # Merge LoRA weights for better inference performance.
         # Note: this is irreversible and changes model saving format
         model.merge_and_unload()
+        # padding_side="left" is required for (batch) inference
+        text_tokenizer.padding_side = "left"
         inference = infer.LocalInference(
             model=model,
             processor=processor,


### PR DESCRIPTION
`text_tokenizer.padding_side=right` is used during model training but needs to be changed to `left` (as expected by the `LocalInference` class to support batch inference and for consistency) for model inference at the end of training run.
