### PR TITLE
Sets max-duration to 1 hour for mcli command

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -61,4 +61,4 @@ run *FLAGS:
     poetry run mcli run -f mcloud.yaml --follow {{FLAGS}}
 
 mcloud *FLAGS:
-    poetry run mcli interactive {{FLAGS}} --cluster ${MCLOUD_CLUSTER} --instance ${MCLOUD_INSTANCE}  --name `whoami` --command "bash -c \"$(cat setup.sh)\"" 
+    poetry run mcli interactive {{FLAGS}} --max-duration 1 --cluster ${MCLOUD_CLUSTER} --instance ${MCLOUD_INSTANCE}  --name `whoami` --command "bash -c \"$(cat setup.sh)\"" 


### PR DESCRIPTION
https://docs.mosaicml.com/projects/mcli/en/latest/training/interactive.html 

max-duration is now required for any mcli interactive runs. Updated the justfile to reflect this. 