### PR TITLE
Add AutoProcessor registration

### DIFF
--- a/ultravox/model/ultravox_processing.py
+++ b/ultravox/model/ultravox_processing.py
@@ -205,4 +205,6 @@ class UltravoxProcessor(transformers.ProcessorMixin):
         return list(set(tokenizer_input_names + audio_processor_input_names))
 
 
+UltravoxProcessor.register_for_auto_class()
+
 transformers.AutoProcessor.register(UltravoxConfig, UltravoxProcessor)


### PR DESCRIPTION
UV 0.4 doesn't currently register the processor.