### PR TITLE
Assert dataset length when using epochs

### DIFF
--- a/ultravox/data/dataset_config.py
+++ b/ultravox/data/dataset_config.py
@@ -11,7 +11,7 @@ class DataDictConfig(BaseModel):
     name: Optional[str] = None
     splits: List[str] = dataclasses.field(default_factory=list)
     num_samples: Optional[int] = None
-    total_samples: int
+    total_samples: int = 1
     weight: float = 1.0
     streaming: bool = True
     user_template: str = "<|audio|>"

--- a/ultravox/data/datasets.py
+++ b/ultravox/data/datasets.py
@@ -298,7 +298,7 @@ class VoiceDataset(SizedIterableDataset):
         self._rng = np.random.default_rng(self._args.shuffle_seed)
         self._weight = 1.0  # the default weight for the dataset
 
-    def _init_dataset(self, dataset: data.Dataset, estimated_length: int = 0) -> None:
+    def _init_dataset(self, dataset: data.Dataset, estimated_length: int = 1) -> None:
         self._dataset = dataset
         # Only required when using epochs when training dataset.
         self._estimated_length = estimated_length
@@ -363,12 +363,12 @@ class VoiceDataset(SizedIterableDataset):
             actual_length += 1
             # If len(dataset) == 0 most likely the dataset is a validation dataset,
             # or the training is using max_steps instead of num_epochs.
-            if actual_length > len(self) and len(self) > 0:
+            if actual_length > len(self) and len(self) > 1:
                 warnings.warn(
                     f"The estimated length {self._estimated_length} has been exceeded for type {type(self._dataset)}. Make sure to update."
                 )
 
-        if actual_length != len(self) and len(self) > 0:
+        if actual_length != len(self) and len(self) > 1:
             warnings.warn(
                 f"Mismatch between estimated length ({self._estimated_length}) and actual length ({actual_length}) for dataset of type {type(self._dataset)}. Make sure to update."
             )
@@ -484,7 +484,7 @@ class LibriSpeechDummyDataset(VoiceDataset):
 
 # Making EmptyDataset a SizedIterableDataset to be compatible with using epochs during training.
 class EmptyDataset(SizedIterableDataset):
-    def __init__(self, estimated_length: int = 0) -> None:
+    def __init__(self, estimated_length: int = 1) -> None:
         self._estimated_length = estimated_length
 
     def __iter__(self):


### PR DESCRIPTION
Right now, max steps and epochs will crash with non generic datasets because their size has been set to 0 by default. As a workaround, the default size is set to 1, and an assert is added to check that real sizes are used when training with epoch. 