### PR TITLE
[70B-Part1] Prefetch weights separately

### DIFF
--- a/mcloud.yaml
+++ b/mcloud.yaml
@@ -10,7 +10,10 @@ integrations:
     git_branch: $UV_BRANCH
     pip_install: poetry==1.7.1
 command: >-
-  cd ultravox && poetry install --no-dev && poetry run python -m ultravox.training.helpers.prefetch_weights $TRAIN_ARGS && poetry run torchrun --nproc_per_node=8 -m ultravox.training.train $TRAIN_ARGS
+  cd ultravox &&
+  poetry install --no-dev &&
+  poetry run python -m ultravox.training.helpers.prefetch_weights $TRAIN_ARGS &&
+  poetry run torchrun --nproc_per_node=8 -m ultravox.training.train $TRAIN_ARGS
 env_variables:
   MLFLOW_TRACKING_URI: databricks
   UV_BRANCH: main

--- a/mcloud.yaml
+++ b/mcloud.yaml
@@ -10,7 +10,7 @@ integrations:
     git_branch: $UV_BRANCH
     pip_install: poetry==1.7.1
 command: >-
-  cd ultravox && poetry install --no-dev && poetry run torchrun --nproc_per_node=8 -m ultravox.training.train $TRAIN_ARGS
+  cd ultravox && poetry install --no-dev && poetry run python -m ultravox.training.helpers.prefetch_weights $TRAIN_ARGS && poetry run torchrun --nproc_per_node=8 -m ultravox.training.train $TRAIN_ARGS
 env_variables:
   MLFLOW_TRACKING_URI: databricks
   UV_BRANCH: main

--- a/ultravox/training/config_base.py
+++ b/ultravox/training/config_base.py
@@ -138,10 +138,20 @@ def fix_hyphens(arg: str):
     return re.sub(r"^--([^=]+)", lambda m: "--" + m.group(1).replace("-", "_"), arg)
 
 
-def get_train_args() -> TrainConfig:
+def get_train_args(args: Optional[List[str]] = None) -> TrainConfig:
+    """
+    Parse the command line arguments and return a TrainConfig object.
+
+    Args:
+        args: The command line arguments. If None, sys.argv[1:] is used.
+            This is mainly useful for testing.
+    """
+    if args is None:
+        args = sys.argv[1:]
+
     return simple_parsing.parse(
         config_class=TrainConfig,
-        config_path="ultravox/training/configs/meta_config.yaml",  # base config file
+        config_path=os.path.join(os.path.dirname(__file__), "configs/meta_config.yaml"),
         add_config_path_arg=True,
-        args=[fix_hyphens(arg) for arg in sys.argv[1:]],
+        args=[fix_hyphens(arg) for arg in args],
     )

--- a/ultravox/training/config_base.py
+++ b/ultravox/training/config_base.py
@@ -2,6 +2,8 @@ import dataclasses
 import datetime
 import logging
 import os
+import re
+import sys
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
@@ -130,3 +132,16 @@ class TrainConfig:
                 "LayerDrop cannot be used in DDP when encoder is not frozen. Disabling LayerDrop."
             )
             self.disable_layerdrop = True
+
+
+def fix_hyphens(arg: str):
+    return re.sub(r"^--([^=]+)", lambda m: "--" + m.group(1).replace("-", "_"), arg)
+
+
+def get_train_args() -> TrainConfig:
+    return simple_parsing.parse(
+        config_class=TrainConfig,
+        config_path="ultravox/training/configs/meta_config.yaml",  # base config file
+        add_config_path_arg=True,
+        args=[fix_hyphens(arg) for arg in sys.argv[1:]],
+    )

--- a/ultravox/training/config_base.py
+++ b/ultravox/training/config_base.py
@@ -138,16 +138,15 @@ def fix_hyphens(arg: str):
     return re.sub(r"^--([^=]+)", lambda m: "--" + m.group(1).replace("-", "_"), arg)
 
 
-def get_train_args(args: Optional[List[str]] = None) -> TrainConfig:
+def get_train_args(override_sys_args: Optional[List[str]] = None) -> TrainConfig:
     """
     Parse the command line arguments and return a TrainConfig object.
 
     Args:
-        args: The command line arguments. If None, sys.argv[1:] is used.
+        override_sys_args: The command line arguments. If None, sys.argv[1:] is used.
             This is mainly useful for testing.
     """
-    if args is None:
-        args = sys.argv[1:]
+    args = override_sys_args or sys.argv[1:]
 
     return simple_parsing.parse(
         config_class=TrainConfig,

--- a/ultravox/training/helpers/prefetch_weights.py
+++ b/ultravox/training/helpers/prefetch_weights.py
@@ -42,7 +42,7 @@ def main(override_sys_args: Optional[List[str]] = None):
         wandb_utils.download_model_from_wandb(args.model_load_dir)
 
     end = datetime.now()
-    print(f"Weights are downloaded in {end - start} seconds")
+    print(f"Weights downloaded in {end - start} seconds")
 
 
 def raise_on_weights_not_downloaded(model_ids: List[str]):

--- a/ultravox/training/helpers/prefetch_weights.py
+++ b/ultravox/training/helpers/prefetch_weights.py
@@ -1,3 +1,4 @@
+from typing import List, Optional
 from datetime import datetime
 
 import huggingface_hub
@@ -8,11 +9,11 @@ from ultravox.training import config_base
 ALLOW_PATTERNS = ["*.safetensors", "*.json"]
 
 
-def main():
+def main(args: Optional[List[str]] = None):
     start = datetime.now()
     print("Downloading weights ...")
 
-    args = config_base.get_train_args()
+    args = config_base.get_train_args(args)
 
     for model_id in [args.text_model, args.audio_model]:
         try:

--- a/ultravox/training/helpers/prefetch_weights.py
+++ b/ultravox/training/helpers/prefetch_weights.py
@@ -24,6 +24,7 @@ def main(override_sys_args: Optional[List[str]] = None):
                 repo_id=model_id, allow_patterns=ALLOW_PATTERNS
             )
             # A backstop to make sure the model is fully downloaded even if ALLOW_PATTERNS is not enough
+            # Using `device_map="meta"` to avoid loading the weights into memory or device
             transformers.AutoModel.from_pretrained(model_id, device_map="meta")
         except huggingface_hub.utils.GatedRepoError as e:
             raise e

--- a/ultravox/training/helpers/prefetch_weights.py
+++ b/ultravox/training/helpers/prefetch_weights.py
@@ -2,8 +2,8 @@ from datetime import datetime
 
 import huggingface_hub
 
-from ultravox.training import config_base
 from ultravox.model import wandb_utils
+from ultravox.training import config_base
 
 ALLOW_PATTERNS = ["*.safetensors", "*.json"]
 

--- a/ultravox/training/helpers/prefetch_weights.py
+++ b/ultravox/training/helpers/prefetch_weights.py
@@ -9,11 +9,11 @@ from ultravox.training import config_base
 ALLOW_PATTERNS = ["*.safetensors", "*.json"]
 
 
-def main(args: Optional[List[str]] = None):
+def main(override_sys_args: Optional[List[str]] = None):
     start = datetime.now()
     print("Downloading weights ...")
 
-    args = config_base.get_train_args(args)
+    args = config_base.get_train_args(override_sys_args)
 
     for model_id in [args.text_model, args.audio_model]:
         try:

--- a/ultravox/training/helpers/prefetch_weights.py
+++ b/ultravox/training/helpers/prefetch_weights.py
@@ -47,12 +47,12 @@ def main(override_sys_args: Optional[List[str]] = None):
 
 def raise_on_weights_not_downloaded(model_ids: List[str]):
     """
-    This is an imperfect check to see if the model weights are downloaded,
-    but it can catch if prefetch_weights.py was not run.
+    This function checks to see if the model weights are downloaded and available locally.
+    If they are not, it raises an error.
     """
     for model_id in model_ids:
-        huggingface_hub.snapshot_download(
-            repo_id=model_id, allow_patterns=ALLOW_PATTERNS, local_files_only=True
+        transformers.AutoModel.from_pretrained(
+            model_id, device_map="meta", local_files_only=True
         )
 
 

--- a/ultravox/training/helpers/prefetch_weights.py
+++ b/ultravox/training/helpers/prefetch_weights.py
@@ -45,5 +45,16 @@ def main(override_sys_args: Optional[List[str]] = None):
     print(f"Weights are downloaded in {end - start} seconds")
 
 
+def raise_on_weights_not_downloaded(model_ids: List[str]):
+    """
+    This is an imperfect check to see if the model weights are downloaded,
+    but it can catch if prefetch_weights.py was not run.
+    """
+    for model_id in model_ids:
+        huggingface_hub.snapshot_download(
+            repo_id=model_id, allow_patterns=ALLOW_PATTERNS, local_files_only=True
+        )
+
+
 if __name__ == "__main__":
     main()

--- a/ultravox/training/helpers/prefetch_weights.py
+++ b/ultravox/training/helpers/prefetch_weights.py
@@ -34,7 +34,7 @@ def main(override_sys_args: Optional[List[str]] = None):
 
         # A backstop to make sure the model is fully downloaded. Scenarios to consider:
         # - ALLOW_PATTERNS is not enough to download all files needed
-        # - The model is local
+        # - The model is local, this will verify that everything is in order
         # Using `device_map="meta"` to avoid loading the weights into memory or device
         transformers.AutoModel.from_pretrained(model_id, device_map="meta")
 

--- a/ultravox/training/helpers/prefetch_weights.py
+++ b/ultravox/training/helpers/prefetch_weights.py
@@ -1,5 +1,5 @@
-from typing import List, Optional
 from datetime import datetime
+from typing import List, Optional
 
 import huggingface_hub
 

--- a/ultravox/training/helpers/prefetch_weights.py
+++ b/ultravox/training/helpers/prefetch_weights.py
@@ -16,7 +16,14 @@ def main(override_sys_args: Optional[List[str]] = None):
 
     args = config_base.get_train_args(override_sys_args)
 
-    for model_id in [args.text_model, args.audio_model]:
+    download_weights([args.text_model, args.audio_model], args.model_load_dir)
+
+    end = datetime.now()
+    print(f"Weights downloaded in {end - start} seconds")
+
+
+def download_weights(model_ids: List[str], model_load_dir: Optional[str] = None):
+    for model_id in model_ids:
         try:
             # Download all model files that match ALLOW_PATTERNS
             # This is faster than .from_pretrained due to parallel downloads
@@ -29,7 +36,7 @@ def main(override_sys_args: Optional[List[str]] = None):
             # We assume that the model is local if it's not found on HF Hub.
             # The `.from_pretrained` call will verify the local case.
             print(
-                f"Model {args.text_model} not found on HF Hub. Skipping download. Error: {e}"
+                f"Model {model_id} not found on HF Hub. Skipping download. Error: {e}"
             )
 
         # A backstop to make sure the model is fully downloaded. Scenarios to consider:
@@ -38,22 +45,8 @@ def main(override_sys_args: Optional[List[str]] = None):
         # Using `device_map="meta"` to avoid loading the weights into memory or device
         transformers.AutoModel.from_pretrained(model_id, device_map="meta")
 
-    if args.model_load_dir and wandb_utils.is_wandb_url(args.model_load_dir):
-        wandb_utils.download_model_from_wandb(args.model_load_dir)
-
-    end = datetime.now()
-    print(f"Weights downloaded in {end - start} seconds")
-
-
-def raise_on_weights_not_downloaded(model_ids: List[str]):
-    """
-    This function checks to see if the model weights are downloaded and available locally.
-    If they are not, it raises an error.
-    """
-    for model_id in model_ids:
-        transformers.AutoModel.from_pretrained(
-            model_id, device_map="meta", local_files_only=True
-        )
+    if model_load_dir and wandb_utils.is_wandb_url(model_load_dir):
+        wandb_utils.download_model_from_wandb(model_load_dir)
 
 
 if __name__ == "__main__":

--- a/ultravox/training/helpers/prefetch_weights.py
+++ b/ultravox/training/helpers/prefetch_weights.py
@@ -1,0 +1,37 @@
+from datetime import datetime
+
+import huggingface_hub
+
+from ultravox.training import config_base
+from ultravox.model import wandb_utils
+
+ALLOW_PATTERNS = ["*.safetensors", "*.json"]
+
+
+def main():
+    start = datetime.now()
+    print("Downloading weights ...")
+
+    args = config_base.get_train_args()
+
+    for model_id in [args.text_model, args.audio_model]:
+        try:
+            huggingface_hub.snapshot_download(
+                repo_id=model_id, allow_patterns=ALLOW_PATTERNS
+            )
+        except huggingface_hub.utils.GatedRepoError as e:
+            raise e
+        except huggingface_hub.utils.RepositoryNotFoundError as e:
+            print(
+                f"Model {args.text_model} not found on HF Hub. Skipping download. Error: {e}"
+            )
+
+    if args.model_load_dir and wandb_utils.is_wandb_url(args.model_load_dir):
+        wandb_utils.download_model_from_wandb(args.model_load_dir)
+
+    end = datetime.now()
+    print(f"Weights are downloaded in {end - start} seconds")
+
+
+if __name__ == "__main__":
+    main()

--- a/ultravox/training/helpers/prefetch_weights_test.py
+++ b/ultravox/training/helpers/prefetch_weights_test.py
@@ -1,5 +1,3 @@
-import transformers
-
 from ultravox.training.helpers import prefetch_weights
 
 TEXT_MODEL = "hf-internal-testing/tiny-random-LlamaForCausalLM"
@@ -14,7 +12,3 @@ def test_prefetch_weights():
     prefetch_weights.main(["--text-model", TEXT_MODEL, "--audio-model", AUDIO_MODEL])
 
     prefetch_weights.raise_on_weights_not_downloaded([TEXT_MODEL, AUDIO_MODEL])
-
-    # With local_files_only=True, from_pretrained will throw an error if the weights are not downloaded
-    transformers.AutoModel.from_pretrained(TEXT_MODEL, local_files_only=True)
-    transformers.AutoModel.from_pretrained(AUDIO_MODEL, local_files_only=True)

--- a/ultravox/training/helpers/prefetch_weights_test.py
+++ b/ultravox/training/helpers/prefetch_weights_test.py
@@ -1,0 +1,13 @@
+import transformers
+from ultravox.training.helpers import prefetch_weights
+
+TEXT_MODEL = "hf-internal-testing/tiny-random-LlamaForCausalLM"
+AUDIO_MODEL = "hf-internal-testing/tiny-random-WhisperForCausalLM"
+
+
+def test_prefetch_weights():
+    prefetch_weights.main(["--text-model", TEXT_MODEL, "--audio-model", AUDIO_MODEL])
+
+    # With local_files_only=True, from_pretrained will throw an error if the weights are not downloaded
+    transformers.AutoModel.from_pretrained(TEXT_MODEL, local_files_only=True)
+    transformers.AutoModel.from_pretrained(AUDIO_MODEL, local_files_only=True)

--- a/ultravox/training/helpers/prefetch_weights_test.py
+++ b/ultravox/training/helpers/prefetch_weights_test.py
@@ -7,7 +7,13 @@ AUDIO_MODEL = "hf-internal-testing/tiny-random-WhisperForCausalLM"
 
 
 def test_prefetch_weights():
+    # It would be nice to test this, but there isn't an easy way to clear the cache
+    # with pytest.raises(huggingface_hub.utils.LocalEntryNotFoundError):
+    #     prefetch_weights.raise_on_weights_not_downloaded([TEXT_MODEL, AUDIO_MODEL])
+
     prefetch_weights.main(["--text-model", TEXT_MODEL, "--audio-model", AUDIO_MODEL])
+
+    prefetch_weights.raise_on_weights_not_downloaded([TEXT_MODEL, AUDIO_MODEL])
 
     # With local_files_only=True, from_pretrained will throw an error if the weights are not downloaded
     transformers.AutoModel.from_pretrained(TEXT_MODEL, local_files_only=True)

--- a/ultravox/training/helpers/prefetch_weights_test.py
+++ b/ultravox/training/helpers/prefetch_weights_test.py
@@ -1,4 +1,5 @@
 import transformers
+
 from ultravox.training.helpers import prefetch_weights
 
 TEXT_MODEL = "hf-internal-testing/tiny-random-LlamaForCausalLM"

--- a/ultravox/training/helpers/prefetch_weights_test.py
+++ b/ultravox/training/helpers/prefetch_weights_test.py
@@ -1,3 +1,5 @@
+import transformers
+
 from ultravox.training.helpers import prefetch_weights
 
 TEXT_MODEL = "hf-internal-testing/tiny-random-LlamaForCausalLM"
@@ -5,10 +7,8 @@ AUDIO_MODEL = "hf-internal-testing/tiny-random-WhisperForCausalLM"
 
 
 def test_prefetch_weights():
-    # It would be nice to test this, but there isn't an easy way to clear the cache
-    # with pytest.raises(huggingface_hub.utils.LocalEntryNotFoundError):
-    #     prefetch_weights.raise_on_weights_not_downloaded([TEXT_MODEL, AUDIO_MODEL])
-
     prefetch_weights.main(["--text-model", TEXT_MODEL, "--audio-model", AUDIO_MODEL])
 
-    prefetch_weights.raise_on_weights_not_downloaded([TEXT_MODEL, AUDIO_MODEL])
+    # With local_files_only=True, from_pretrained will throw an error if the weights are not downloaded
+    transformers.AutoModel.from_pretrained(TEXT_MODEL, local_files_only=True)
+    transformers.AutoModel.from_pretrained(AUDIO_MODEL, local_files_only=True)

--- a/ultravox/training/train.py
+++ b/ultravox/training/train.py
@@ -4,16 +4,13 @@ import gc
 import glob
 import logging
 import os
-import re
 import subprocess
-import sys
 from datetime import datetime
 from typing import Dict, List, Optional
 
 import datasets as hf_datasets
 import pandas as pd
 import safetensors.torch
-import simple_parsing
 import torch
 import torch.distributed
 import transformers
@@ -32,10 +29,6 @@ from ultravox.training import config_base
 
 INPUT_EXAMPLE = {"text": "Transcribe\n<|audio|>", "audio": b"\x00\x00" * 16000}
 OUTPUT_EXAMPLE = {"text": "Hello, world!"}
-
-
-def fix_hyphens(arg: str):
-    return re.sub(r"^--([^=]+)", lambda m: "--" + m.group(1).replace("-", "_"), arg)
 
 
 def prepare_dataset(
@@ -75,12 +68,7 @@ def main() -> None:
     os.environ["WANDB_LOG_MODEL"] = "checkpoint"
     os.environ["WANDB_PROJECT"] = "ultravox"
 
-    args = simple_parsing.parse(
-        config_class=config_base.TrainConfig,
-        config_path="ultravox/training/configs/meta_config.yaml",  # base config file
-        add_config_path_arg=True,
-        args=[fix_hyphens(arg) for arg in sys.argv[1:]],
-    )
+    args = config_base.get_train_args()
 
     transformers.set_seed(args.seed)
 

--- a/ultravox/training/train.py
+++ b/ultravox/training/train.py
@@ -29,7 +29,6 @@ from ultravox.model import ultravox_pipeline
 from ultravox.model import ultravox_processing
 from ultravox.model import wandb_utils
 from ultravox.training import config_base
-from ultravox.training import ddp_utils
 
 INPUT_EXAMPLE = {"text": "Transcribe\n<|audio|>", "audio": b"\x00\x00" * 16000}
 OUTPUT_EXAMPLE = {"text": "Hello, world!"}


### PR DESCRIPTION
This PR allows for downloading the weights of the model first, before starting the DDP processes. The previous approach tends to time out when using 70B model.