### PR TITLE
[70B-Part3] FSDP Training

### DIFF
--- a/ultravox/model/ultravox_model.py
+++ b/ultravox/model/ultravox_model.py
@@ -51,12 +51,11 @@ class UltravoxModel(transformers.LlamaPreTrainedModel):
         self.vocab_size = config.vocab_size
 
         self.audio_tower = self._create_audio_tower(config)
-        self.multi_modal_projector = UltravoxProjector(config)
+        self.multi_modal_projector = self._create_multi_modal_projector(config)
         self.language_model = self._create_language_model(config)
 
         self.loss_config = LossConfig()
         self.post_init()
-        self.multi_modal_projector.to(dtype=config.torch_dtype)
 
     def get_input_embeddings(self):
         return self.language_model.get_input_embeddings()
@@ -265,6 +264,14 @@ class UltravoxModel(transformers.LlamaPreTrainedModel):
             model_input["audio_token_len"] = audio_token_len
 
         return model_input
+
+    @classmethod
+    def _create_multi_modal_projector(
+        cls, config: UltravoxConfig
+    ) -> "UltravoxProjector":
+        projector = UltravoxProjector(config)
+        projector.to(config.torch_dtype)
+        return projector
 
     @classmethod
     def _create_audio_tower(

--- a/ultravox/training/config_base.py
+++ b/ultravox/training/config_base.py
@@ -75,7 +75,9 @@ class TrainConfig:
     optimizer: str = "adamw_torch"
     num_epochs: int = 1
     max_steps: int = 0
+    # Run an evaluation every X steps. If smaller than 1, will be interpreted as ratio of total training steps.
     val_steps: Optional[float] = None
+    # Save checkpoint every X steps. If smaller than 1, will be interpreted as ratio of total training steps.
     save_steps: float = 0
     logging_steps: int = 1
     grad_accum_steps: int = 1
@@ -141,6 +143,12 @@ class TrainConfig:
                 "FSDP is enabled: Saving checkpoints is going to be extremely slow and results in a full save."
                 " Consider setting save_steps=0."
             )
+
+        if self.use_fsdp and self.do_eval:
+            logging.warning(
+                "FSDP is enabled: Evaluation is not supported with FSDP. Disabling evaluation."
+            )
+            self.do_eval = False
 
 
 def fix_hyphens(arg: str):

--- a/ultravox/training/config_base.py
+++ b/ultravox/training/config_base.py
@@ -57,6 +57,9 @@ class TrainConfig:
 
     device: str = "cuda"
     data_type: str = "bfloat16"
+    # Whether to use FSDP (Fully Sharded Data Parallelism) for training
+    # needed for large model training (e.g. 70B+)
+    use_fsdp: bool = False
     # Path to load the model from. Can be local path, HF hub model_id, or W&B artifact
     model_load_dir: Optional[str] = None
     text_model_lora_config: Optional[ultravox_config.LoraConfigSimplified] = None
@@ -70,7 +73,7 @@ class TrainConfig:
     optimizer: str = "adamw_torch"
     num_epochs: int = 1
     max_steps: int = 0
-    val_steps: Optional[int] = None
+    val_steps: Optional[float] = None
     save_steps: float = 0
     logging_steps: int = 1
     grad_accum_steps: int = 1
@@ -130,3 +133,9 @@ class TrainConfig:
                 "LayerDrop cannot be used in DDP when encoder is not frozen. Disabling LayerDrop."
             )
             self.disable_layerdrop = True
+
+        if self.use_fsdp and self.save_steps:
+            logging.warning(
+                "FSDP is enabled: Saving checkpoints is going to be extremely slow and results in a full save."
+                " Consider setting save_steps=0."
+            )

--- a/ultravox/training/config_base.py
+++ b/ultravox/training/config_base.py
@@ -142,6 +142,7 @@ class TrainConfig:
                 " Consider setting save_steps=0."
             )
 
+
 def fix_hyphens(arg: str):
     return re.sub(r"^--([^=]+)", lambda m: "--" + m.group(1).replace("-", "_"), arg)
 

--- a/ultravox/training/train.py
+++ b/ultravox/training/train.py
@@ -324,6 +324,8 @@ def train(args: config_base.TrainConfig):
         logging.info(f"elapsed: {t_end - t_start}")
 
     if args.use_fsdp:
+        # For training checkpoints, we want to use SHARDED_STATE_DICT which should be faster,
+        # but for the final save we want FULL_STATE_DICT so it can be serialized properly.
         trainer.accelerator.state.fsdp_plugin.set_state_dict_type("FULL_STATE_DICT")
 
     if is_master:

--- a/ultravox/training/train.py
+++ b/ultravox/training/train.py
@@ -185,7 +185,10 @@ def train(args: config_base.TrainConfig):
 
     model.print_trainable_parameters()
 
-    # TODO: move to device if not fsdp or will trainer do this?
+    if not args.use_fsdp:
+        # Moving to device in FSDP is handled by the Trainer
+        model.to(device=torch.device(args.device, index=local_rank))
+        logging.info(f"Using device (world_size): {model.device} ({world_size})")
 
     # Prepare dataset, subsetting if needed
     train_dataset: data.IterableDataset

--- a/ultravox/training/train.py
+++ b/ultravox/training/train.py
@@ -125,6 +125,8 @@ def train(args: config_base.TrainConfig):
         text_model_id=args.text_model,
         text_model_lora_config=args.text_model_lora_config,
         audio_model_lora_config=args.audio_model_lora_config,
+        torch_dtype=args.data_type,
+        pad_token_id=text_tokenizer.eos_token_id,
     )
 
     logging.info("Instantiating model...")
@@ -183,13 +185,7 @@ def train(args: config_base.TrainConfig):
 
     model.print_trainable_parameters()
 
-    # Move the model to GPU and enable bfloat16
-    dtype = getattr(torch, args.data_type)
-    device = torch.device(args.device, index=local_rank)
-    logging.info(
-        f"Using dtype and device (world_size): {dtype}, {device} ({world_size})"
-    )
-    model.to(device=device, dtype=dtype)
+    # TODO: move to device if not fsdp or will trainer do this?
 
     # Prepare dataset, subsetting if needed
     train_dataset: data.IterableDataset
@@ -275,9 +271,9 @@ def train(args: config_base.TrainConfig):
             optim=args.optimizer,
             num_train_epochs=args.num_epochs,
             max_steps=args.max_steps,
-            evaluation_strategy="steps",
+            eval_strategy="steps" if args.val_steps else "no",
             eval_steps=args.val_steps,
-            save_strategy="steps",
+            save_strategy="steps" if args.save_steps else "no",
             save_steps=args.save_steps,
             logging_first_step=True,
             logging_dir=args.logs_dir,
@@ -294,14 +290,19 @@ def train(args: config_base.TrainConfig):
             lr_scheduler_type=args.lr_scheduler,
             warmup_steps=args.lr_warmup_steps,
             weight_decay=args.weight_decay,
-            fp16=dtype == torch.float16,
-            bf16=dtype == torch.bfloat16,
+            # fp16=dtype == torch.float16,
+            # bf16=dtype == torch.bfloat16,
             use_cpu=args.device == "cpu",
             seed=args.seed + local_rank,
             report_to=args.report_logs_to,
             # torch_compile=True,
-            # fsdp="full_shard auto_wrap",
-            # fsdp_transformer_layer_cls_to_wrap='LlamaDecoderLayer',
+            fsdp="full_shard auto_wrap" if args.use_fsdp else "",
+            fsdp_config={
+                "backward_prefetch": "backward_pre",
+                "auto_wrap_policy": "TRANSFORMER_BASED_WRAP",
+                "state_dict_type": "SHARDED_STATE_DICT",
+                "sync_module_states": "true",
+            },
         ),
     )
 
@@ -310,17 +311,27 @@ def train(args: config_base.TrainConfig):
         logging.info("Starting training...")
         t_start = datetime.now()
         logging.info(f"train start time: {t_start}")
+
         if args.val_steps:
-            trainer.evaluate()
+            if args.use_fsdp:
+                logging.warning(
+                    "FSDP is enabled: Skipping initial validation since model is not initialized."
+                )
+            else:
+                trainer.evaluate()
+
         trainer.train()
         t_end = datetime.now()
         logging.info(f"train end time: {t_end}")
         logging.info(f"elapsed: {t_end - t_start}")
 
+    if args.use_fsdp:
+        trainer.accelerator.state.fsdp_plugin.set_state_dict_type("FULL_STATE_DICT")
+
     if is_master:
         # Saving the model using pipeline to ensure its code is saved
         pipeline = ultravox_pipeline.UltravoxPipeline(
-            model, tokenizer=text_tokenizer, device=device
+            model, tokenizer=text_tokenizer, device=model.device
         )
         pipeline.save_pretrained(args.output_dir)
 


### PR DESCRIPTION
This PR is mostly complete, but I do need to revisit some minor assumptions to make sure I didn't break the normal (non-fsdp) pipeline.

One of the odd changes here is the removal of `.to(device, dtype)`.
- The `dtype` part is moved into the model itself since it'll cost us too much to possibly be sloppy and load a full-precision 70B and then turn it into half precision.
- The `device` part is being handled by the `trainer` itself when doing `trainer.train`. This causes some minor issues (e.g. running `trainer.evaluate` before is not allowed), but they're not hugely important.
    - note that now `model.device` is `cpu` (or mps) before `trainer.train` and then `cuda:rank` after `trainer.train`. This might take some getting used to.