### PR TITLE
Support longer audio contexts

### DIFF
--- a/ultravox/data/datasets.py
+++ b/ultravox/data/datasets.py
@@ -79,6 +79,7 @@ class DataCollatorForSeq2SeqWithAudio(transformers.DataCollatorForSeq2Seq):
 
     def __call__(self, features, *args, **kwargs):
         audio_values = [f.pop("audio_values", None) for f in features]
+
         if self.include_alt_fields:
             # these fields are hard-coded in the transformer data collator, so they need special handling before calling the super method
             alt_features = [
@@ -89,6 +90,7 @@ class DataCollatorForSeq2SeqWithAudio(transformers.DataCollatorForSeq2Seq):
                 }
                 for f in features
             ]
+
         input_ids_lens = torch.LongTensor([f["input_ids"].shape[-1] for f in features])
         batch = super().__call__(features, *args, **kwargs)
         if self.include_alt_fields:
@@ -100,7 +102,7 @@ class DataCollatorForSeq2SeqWithAudio(transformers.DataCollatorForSeq2Seq):
         # Pad the last dimension of all audio_values to the same length, with 0s on the right.
         if audio_values and audio_values[0] is not None:
             max_len = max([x.shape[-1] for x in audio_values])
-            batch["audio_values"] = torch.stack(
+            batch["audio_values"] = torch.cat(
                 [F.pad(x, (0, max_len - x.shape[-1])) for x in audio_values]
             )
             if self.tokenizer.padding_side == "left":
@@ -108,7 +110,6 @@ class DataCollatorForSeq2SeqWithAudio(transformers.DataCollatorForSeq2Seq):
                 batch["audio_token_start_idx"] += displacement.to(
                     batch["audio_token_start_idx"].device
                 )
-
         return batch
 
 

--- a/ultravox/inference/infer.py
+++ b/ultravox/inference/infer.py
@@ -199,7 +199,6 @@ class LocalInference(base.VoiceInference):
             text=text_input,
             return_tensors="pt",
             sampling_rate=SAMPLE_RATE,
-            audio_context_size=self.model.audio_tower_context_length,
         )
         inputs = {k: v.to(self.model.device) for k, v in inputs.items()}
         if "audio_values" in inputs:

--- a/ultravox/inference/infer.py
+++ b/ultravox/inference/infer.py
@@ -111,7 +111,8 @@ class LocalInference(base.VoiceInference):
         inputs = [self._dataproc(s) for s in samples]
         for input in inputs:
             for key, val in input.items():
-                input[key] = val.squeeze(0)
+                if key != "audio_values":
+                    input[key] = val.squeeze(0)
 
         tensors = self.data_collator(inputs)
         input_len = tensors["input_ids"].shape[1]
@@ -198,6 +199,7 @@ class LocalInference(base.VoiceInference):
             text=text_input,
             return_tensors="pt",
             sampling_rate=SAMPLE_RATE,
+            audio_context_size=self.model.audio_tower_context_length,
         )
         inputs = {k: v.to(self.model.device) for k, v in inputs.items()}
         if "audio_values" in inputs:

--- a/ultravox/inference/infer_test.py
+++ b/ultravox/inference/infer_test.py
@@ -60,7 +60,7 @@ class FakeInference(infer.LocalInference):
         )
         self.model.device = "cpu"
         self.model.generate = mock.MagicMock(side_effect=fake_generate)
-        self.model.audio_tower_context_length = 3000
+        self.model.audio_tower_context_length = None
 
 
 EXPECTED_TOKEN_IDS_START = [128000, 128006, 882, 128007]

--- a/ultravox/inference/infer_test.py
+++ b/ultravox/inference/infer_test.py
@@ -49,7 +49,7 @@ class FakeInference(infer.LocalInference):
             return output
 
         processor = ultravox_processing.UltravoxProcessor(
-            audio_processor, tokenizer=tokenizer
+            audio_processor, tokenizer=tokenizer, audio_context_size=None
         )
         super().__init__(
             mock.MagicMock(),
@@ -60,7 +60,6 @@ class FakeInference(infer.LocalInference):
         )
         self.model.device = "cpu"
         self.model.generate = mock.MagicMock(side_effect=fake_generate)
-        self.model.audio_tower_context_length = None
 
 
 EXPECTED_TOKEN_IDS_START = [128000, 128006, 882, 128007]

--- a/ultravox/inference/infer_test.py
+++ b/ultravox/inference/infer_test.py
@@ -60,6 +60,7 @@ class FakeInference(infer.LocalInference):
         )
         self.model.device = "cpu"
         self.model.generate = mock.MagicMock(side_effect=fake_generate)
+        self.model.audio_tower_context_length = 3000
 
 
 EXPECTED_TOKEN_IDS_START = [128000, 128006, 882, 128007]

--- a/ultravox/inference/ultravox_infer.py
+++ b/ultravox/inference/ultravox_infer.py
@@ -58,7 +58,10 @@ class UltravoxInference(infer.LocalInference):
         )
 
         processor = ultravox_processing.UltravoxProcessor(
-            audio_processor, tokenizer=tokenizer, stack_factor=model.config.stack_factor
+            audio_processor,
+            tokenizer=tokenizer,
+            stack_factor=model.config.stack_factor,
+            audio_context_size=model.audio_tower_context_length,
         )
 
         super().__init__(

--- a/ultravox/model/ultravox_model.py
+++ b/ultravox/model/ultravox_model.py
@@ -51,8 +51,8 @@ class UltravoxModel(transformers.LlamaPreTrainedModel):
         self.vocab_size = config.vocab_size
 
         self.audio_tower = self._create_audio_tower(config)
-        self.audio_tower_context_length = None
-        if "whisper" in config.audio_model_id is not None:
+        self.audio_tower_context_length: Optional[int] = None
+        if config.audio_model_id is not None and "whisper" in config.audio_model_id:
             self.audio_tower_context_length = 3000
 
         self.multi_modal_projector = UltravoxProjector(config)
@@ -186,11 +186,13 @@ class UltravoxModel(transformers.LlamaPreTrainedModel):
         if audio_values is not None:
 
             assert (
-                audio_token_start_idx is not None and audio_token_len is not None
-            ), "audio_token_start_idx and audio_token_len must be provided if audio_values are provided."
+                audio_token_start_idx is not None
+                and audio_token_len is not None
+                and batch_size is not None
+            ), "audio_token_start_idx and audio_token_len and batch_size must be provided if audio_values are provided."
             assert (
                 len(audio_token_start_idx) == len(audio_token_len) == len(batch_size)
-            ), "audio_token_start_idx and audio_token_len must have the same batch size."
+            ), "audio_token_start_idx and audio_token_len and batch_size must have the same batch size."
 
             audio_tower_output = self.audio_tower.forward(
                 audio_values

--- a/ultravox/model/ultravox_model.py
+++ b/ultravox/model/ultravox_model.py
@@ -51,8 +51,10 @@ class UltravoxModel(transformers.LlamaPreTrainedModel):
         self.vocab_size = config.vocab_size
 
         self.audio_tower = self._create_audio_tower(config)
-        self.audio_tower_context_length = 3000  # the context window for the whisper model
-        
+        self.audio_tower_context_length = (
+            3000  # the context window for the whisper model
+        )
+
         self.multi_modal_projector = UltravoxProjector(config)
         self.language_model = self._create_language_model(config)
 
@@ -189,7 +191,6 @@ class UltravoxModel(transformers.LlamaPreTrainedModel):
             ), "audio_token_start_idx, audio_token_len, and audio_values must have the same batch size."
 
             # Check if the audio_values T dimension is greater than whisper encoder's context window.
-            print("audio values shape: ", audio_values.shape)
             if audio_values.shape[2] > self.audio_tower_context_length:
                 audio_values_chunks = torch.split(
                     audio_values, self.audio_tower_context_length, dim=2

--- a/ultravox/model/ultravox_pipeline.py
+++ b/ultravox/model/ultravox_pipeline.py
@@ -37,6 +37,7 @@ class UltravoxPipeline(transformers.Pipeline):
             audio_processor=audio_processor,
             tokenizer=tokenizer,
             stack_factor=model.config.stack_factor,
+            audio_context_size=model.audio_tower_context_length,
         )
 
         super().__init__(model=model, tokenizer=tokenizer, **kwargs)

--- a/ultravox/model/ultravox_processing.py
+++ b/ultravox/model/ultravox_processing.py
@@ -165,8 +165,6 @@ class UltravoxProcessor(transformers.ProcessorMixin):
                 audio_values = x.input_values
 
             audio_values = torch.tensor(audio_values)
-            print("audio values shape", audio_values.shape)
-            print("audio_context_size", audio_context_size)
             if audio_context_size and audio_values.shape[-1] > audio_context_size:
                 audio_values_chunks = list(
                     torch.split(
@@ -207,7 +205,6 @@ class UltravoxProcessor(transformers.ProcessorMixin):
                         add_special_tokens=False,
                     )
                 )
-
                 data["audio_token_start_idx"] = [start_idx]
 
                 # Replace the audio placeholder with the audio token.

--- a/ultravox/model/ultravox_processing.py
+++ b/ultravox/model/ultravox_processing.py
@@ -193,7 +193,7 @@ class UltravoxProcessor(transformers.ProcessorMixin):
             data["audio_values"] = torch.cat(audio_values_chunks)
             num_audio_chunks = data["audio_values"].shape[0]
 
-            data["batch_size"] = [num_audio_chunks]
+            data["audio_batch_size"] = [num_audio_chunks]
 
         if text is not None:
             assert isinstance(

--- a/ultravox/training/train.py
+++ b/ultravox/training/train.py
@@ -117,7 +117,6 @@ def train(args: config_base.TrainConfig):
     text_tokenizer.padding_side = "right"
     text_tokenizer.pad_token = text_tokenizer.eos_token
     audio_processor = transformers.AutoProcessor.from_pretrained(args.audio_model)
-    processor = ultravox_processing.UltravoxProcessor(audio_processor, text_tokenizer)
 
     # Instantiate the model and processor
     config = ultravox_config.UltravoxConfig(
@@ -133,6 +132,12 @@ def train(args: config_base.TrainConfig):
     # downloading before the others start in order to avoid race conditions.
     with ddp_utils.run_on_master_first(is_master):
         model = ultravox_model.UltravoxModel(config)
+
+    processor = ultravox_processing.UltravoxProcessor(
+        audio_processor,
+        text_tokenizer,
+        audio_context_size=model.audio_tower_context_length,
+    )
 
     assert model.get_input_embeddings().num_embeddings == len(
         text_tokenizer


### PR DESCRIPTION
The whisper encoder has a max context of 30s of audio. 

This pr enables our model to support longer contexts by splitting long audio into chunks of 30sec (with the last chunk being the exception)

Note* should also work in batch mode. 