### PR TITLE
Create test for config_base.py

### DIFF
--- a/ultravox/training/config_base.py
+++ b/ultravox/training/config_base.py
@@ -167,7 +167,7 @@ def get_train_args(override_sys_args: Optional[List[str]] = None) -> TrainConfig
         override_sys_args: The command line arguments. If None, sys.argv[1:] is used.
             This is mainly useful for testing.
     """
-    args = override_sys_args or sys.argv[1:]
+    args = sys.argv[1:] if override_sys_args is None else override_sys_args
 
     return simple_parsing.parse(
         config_class=TrainConfig,

--- a/ultravox/training/config_base_test.py
+++ b/ultravox/training/config_base_test.py
@@ -2,6 +2,6 @@ from ultravox.training import config_base
 
 
 def test_can_create_train_config():
-    # override args so we don't have to pass in pytest arguments
+    # override args to [], otherwise pytest arguments will be used
     args = config_base.get_train_args([])
     assert isinstance(args, config_base.TrainConfig)

--- a/ultravox/training/config_base_test.py
+++ b/ultravox/training/config_base_test.py
@@ -1,5 +1,6 @@
 from ultravox.training import config_base
 
+
 def test_can_create_train_config():
     args = config_base.get_train_args()
     assert isinstance(args, config_base.TrainConfig)

--- a/ultravox/training/config_base_test.py
+++ b/ultravox/training/config_base_test.py
@@ -2,5 +2,6 @@ from ultravox.training import config_base
 
 
 def test_can_create_train_config():
-    args = config_base.get_train_args()
+    # override args so we don't have to pass in pytest arguments
+    args = config_base.get_train_args([])
     assert isinstance(args, config_base.TrainConfig)

--- a/ultravox/training/config_base_test.py
+++ b/ultravox/training/config_base_test.py
@@ -1,0 +1,5 @@
+from ultravox.training import config_base
+
+def test_can_create_train_config():
+    args = config_base.get_train_args()
+    assert isinstance(args, config_base.TrainConfig)


### PR DESCRIPTION
The test for `prefetch_weights.py` assumes that the training config can be created by default. When that fails, it can be very confusing since the user thinks the issue is with `prefetch_weights`, when in fact it's a config issue (whether it's coming from `TrainConfig` or `meta_config.yaml`).

This test won't remove that issue, but at least it makes it easier to figure out where the source of the issue is.