### PR TITLE
Dataset Tool to add Timestamps

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -3,6 +3,7 @@ export WANDB_LOG_MODEL:="checkpoint"
 export PROJECT_DIR:="ultravox"
 export MCLOUD_CLUSTER:="r7z22p1"
 export MCLOUD_INSTANCE:="oci.bm.gpu.b4.8"
+export MFA_ENV_NAME:="aligner"
 
 default: format check test
 
@@ -62,3 +63,34 @@ run *FLAGS:
 
 mcloud *FLAGS:
     poetry run mcli interactive {{FLAGS}} --cluster ${MCLOUD_CLUSTER} --instance ${MCLOUD_INSTANCE}  --name `whoami` --command "bash -c \"$(cat setup.sh)\"" 
+
+@check_conda:
+    if ! command -v conda &> /dev/null; then  \
+        echo "Conda is not installed.";  \
+        mkdir -p ~/miniconda3;  \
+        if [[ "$OSTYPE" == "darwin"* ]]; then  \
+            echo "Downloading MacOS Miniconda.";  \
+            curl https://repo.anaconda.com/miniconda/Miniconda3-latest-MacOSX-arm64.sh -o ~/miniconda3/miniconda.sh;  \
+        elif [[ "$OSTYPE" == "linux-gnu"* ]]; then  \
+            echo "Downloading Linux Miniconda.";  \
+            wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh -O ~/miniconda3/miniconda.sh  \
+        else  \
+            echo "Unknown operating system.";  \
+        fi;  \
+        bash ~/miniconda3/miniconda.sh -b -u -p ~/miniconda3;  \
+        rm ~/miniconda3/miniconda.sh;  \
+    else  \
+        echo "Conda is installed.";  \
+    fi
+
+@install_mfa: check_conda
+    if conda env list | grep -q "$MFA_ENV_NAME"; then  \
+        echo "Environment '$MFA_ENV_NAME' already exists.";  \
+    else  \
+        echo "Creating environment '$MFA_ENV_NAME'.";  \
+        conda create --name "$MFA_ENV_NAME" python=3.8 -y;  \
+        conda create -n "$MFA_ENV_NAME" -c conda-forge montreal-forced-aligner;  \
+        conda activate "$MFA_ENV_NAME";  \
+        mfa model download acoustic english_mfa;  \
+        mfa model download dictionary english_mfa;  \
+    fi

--- a/Justfile
+++ b/Justfile
@@ -68,10 +68,10 @@ mcloud *FLAGS:
     if ! command -v conda &> /dev/null; then  \
         echo "Conda is not installed.";  \
         mkdir -p ~/miniconda3;  \
-        if [[ "$OSTYPE" == "darwin"* ]]; then  \
+        if [ "$(uname)" = "Darwin" ]; then  \
             echo "Downloading MacOS Miniconda.";  \
             curl https://repo.anaconda.com/miniconda/Miniconda3-latest-MacOSX-arm64.sh -o ~/miniconda3/miniconda.sh;  \
-        elif [[ "$OSTYPE" == "linux-gnu"* ]]; then  \
+        elif [ "$(uname)" = "Linux" ]; then  \
             echo "Downloading Linux Miniconda.";  \
             wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh -O ~/miniconda3/miniconda.sh  \
         else  \
@@ -90,7 +90,6 @@ mcloud *FLAGS:
         echo "Creating environment '$MFA_ENV_NAME'.";  \
         conda create --name "$MFA_ENV_NAME" python=3.8 -y;  \
         conda create -n "$MFA_ENV_NAME" -c conda-forge montreal-forced-aligner;  \
-        conda activate "$MFA_ENV_NAME";  \
-        mfa model download acoustic english_mfa;  \
-        mfa model download dictionary english_mfa;  \
+        conda run -n "$MFA_ENV_NAME" mfa model download acoustic english_mfa;  \
+        conda run -n "$MFA_ENV_NAME" mfa model download dictionary english_mfa;  \
     fi

--- a/poetry.lock
+++ b/poetry.lock
@@ -5125,6 +5125,20 @@ redis = ["redis"]
 tests = ["pytest (>=5.4.1)", "pytest-cov (>=2.8.1)", "pytest-mypy (>=0.8.0)", "pytest-timeout (>=2.1.0)", "redis", "sphinx (>=6.0.0)", "types-redis"]
 
 [[package]]
+name = "praatio"
+version = "6.2.0"
+description = "A library for working with praat, textgrids, time aligned audio transcripts, and audio files."
+optional = false
+python-versions = ">3.6.0"
+files = [
+    {file = "praatio-6.2.0-py3-none-any.whl", hash = "sha256:6541018791a3f0b087a8168d1746a165937c3fff1f94c7a6883b3f470e0cf405"},
+    {file = "praatio-6.2.0.tar.gz", hash = "sha256:7d2a7f8135a3e0691743ada0af84308b64e637f07038cea77d814b8aa2fa2e40"},
+]
+
+[package.dependencies]
+typing-extensions = "*"
+
+[[package]]
 name = "preshed"
 version = "3.0.9"
 description = "Cython hash table that trusts the keys are pre-hashed"
@@ -8883,4 +8897,4 @@ files = [
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.10,<4.0"
-content-hash = "798d26eeecb0625e6e6b655f7209286319924de573c9cdd9a30416593a492cb5"
+content-hash = "f1d462cee8239c355f81406ff7ee88e42fd85b955abec54aac629ef2cd4a4cce"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ wandb = "~0.17.1"
 sacrebleu = "^2.4.2"
 tenacity = "^9.0.0"
 evals = {git = "https://github.com/fixie-ai/evals", rev = "0c66bf85df7a4b903ecb202b23c2a826b749fd71"}
+praatio = "^6.2.0"
 
 [tool.poetry.group.dev.dependencies]
 black = "~24.4.2"

--- a/ultravox/tools/ds_tool/ds_tool.py
+++ b/ultravox/tools/ds_tool/ds_tool.py
@@ -216,7 +216,7 @@ class TimestampGenerationTask:
     # For many languages there exists a {language}_mfa model that you can use, e.g. "english_mfa"
     mfa_acoustic_model: str = simple_parsing.field(alias="-m")
     # The dictionary to use for MFA alignment. Defaults to the same name as the acoustic model.
-    mfa_dictionary: str = simple_parsing.field(default=None, alias="-d")
+    mfa_dictionary: Optional[str] = simple_parsing.field(default=None, alias="-d")
     audio_column_name: str = simple_parsing.field(default="audio", alias="-a")
     sample_rate: int = simple_parsing.field(default=16000, alias="-r")
     # The column name to store the timestamps in
@@ -352,7 +352,7 @@ class TimestampGenerationTask:
                 str(num_proc),
                 temp_dir,
                 self.mfa_acoustic_model,
-                self.mfa_dictionary,
+                str(self.mfa_dictionary),
                 temp_dir,
             ],
             check=True,

--- a/ultravox/tools/ds_tool/ds_tool.py
+++ b/ultravox/tools/ds_tool/ds_tool.py
@@ -419,6 +419,11 @@ class DatasetToolArgs:
         if self.dataset_split and not self.upload_split:
             self.upload_split = self.dataset_split
 
+        if self.upload_name == self.dataset_name:
+            raise ValueError(
+                "Updating datasets in-place is not well-supported and hence frowned upon."
+            )
+
 
 class DatasetChunkProcessor:
     args: DatasetToolArgs

--- a/ultravox/tools/ds_tool/ds_tool.py
+++ b/ultravox/tools/ds_tool/ds_tool.py
@@ -234,7 +234,6 @@ class TimestampGenerationTask:
                 "align",
                 "--clean",
                 "--use_mp",
-                "--single_speaker",
                 temp_dir,
                 "english_mfa",
                 "english_mfa",

--- a/ultravox/tools/ds_tool/ds_tool.py
+++ b/ultravox/tools/ds_tool/ds_tool.py
@@ -396,7 +396,7 @@ class DatasetToolArgs:
 
     task: Union[TtsTask, TextGenerationTask, TimestampGenerationTask] = (
         simple_parsing.subgroups(
-            {"tts": TtsTask, "textgen": TextGenerationTask, "ts": TimestampGenerationTask},  # type: ignore
+            {"tts": TtsTask, "textgen": TextGenerationTask, "timestamp": TimestampGenerationTask},  # type: ignore
             default_factory=TtsTask,
             positional=True,
         )

--- a/ultravox/tools/ds_tool/ds_tool.py
+++ b/ultravox/tools/ds_tool/ds_tool.py
@@ -2,8 +2,8 @@ import dataclasses
 import json
 import math
 import os
-import tempfile
 import subprocess
+import tempfile
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple, Union
 
@@ -13,8 +13,8 @@ import librosa
 import openai
 import simple_parsing
 import soundfile as sf
-from praatio import textgrid
 import yaml
+from praatio import textgrid
 from tenacity import retry
 from tenacity import stop_after_attempt
 from tenacity import wait_fixed

--- a/ultravox/tools/ds_tool/ds_tool.py
+++ b/ultravox/tools/ds_tool/ds_tool.py
@@ -204,7 +204,8 @@ class TimestampGenerationTask:
     This task is used to generate timestamps for the text transcription.
     It uses the Montreal Forced Aligner (MFA) to align the text with the audio. The result is a
     list of timestamps for each word in the text transcription. The timestamps are stored in a new
-    column, in a dictionary format: {"start": float in seconds, "end": float in seconds, "text": word str}.
+    column, in a list of dict format:
+        [ {"start": float in seconds, "end": float in seconds, "text": first word str}, ... ]
     """
 
     # Jinja template for the text transcription that needs to be aligned

--- a/ultravox/tools/ds_tool/ds_tool.py
+++ b/ultravox/tools/ds_tool/ds_tool.py
@@ -148,7 +148,7 @@ class TimestampGenerationTask:
         )
 
         # 2. run the alignment
-        self._run_alignment(self.temp_dir)
+        self._run_alignment(self.temp_dir, num_proc=num_proc)
 
         # 3. retrieve the timestamps
         ds_mapped = ds_split.map(
@@ -222,7 +222,7 @@ class TimestampGenerationTask:
 
         return None
 
-    def _run_alignment(self, temp_dir: str) -> None:
+    def _run_alignment(self, temp_dir: str, num_proc: int = 16) -> None:
         subprocess.run(
             [
                 "conda",
@@ -234,6 +234,8 @@ class TimestampGenerationTask:
                 "align",
                 "--clean",
                 "--use_mp",
+                "-j",
+                str(num_proc),
                 temp_dir,
                 "english_mfa",
                 "english_mfa",

--- a/ultravox/tools/ds_tool/ds_tool.py
+++ b/ultravox/tools/ds_tool/ds_tool.py
@@ -5,6 +5,7 @@ import math
 import os
 import subprocess
 import tempfile
+import traceback
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Set, Tuple, Union
 
@@ -477,8 +478,6 @@ class DatasetChunkProcessor:
                 # If the error is unsupported operand type(s) for -=: 'NoneType' and 'float',
                 # then the huggingface README needs to be updated to have the
                 # download_size, and dataset_size fields present under dataset_info (could be initalized to 0)
-                import traceback
-
                 print(f"Failed to upload chunk {ds_chunk_name}: {e}. Retrying later.")
                 print(traceback.format_exc())
                 if total_chunks == 1:

--- a/ultravox/tools/ds_tool/ds_tool.py
+++ b/ultravox/tools/ds_tool/ds_tool.py
@@ -259,7 +259,7 @@ class TimestampGenerationTask:
         )
 
         count_wavs = len(glob.glob(os.path.join(self.temp_dir, "*.wav")))
-        assert count_wavs >= len(
+        assert count_wavs == len(
             ds_split
         ), "Not all samples were stored as files. The id is likely not unique."
 

--- a/ultravox/tools/ds_tool/ds_tool.py
+++ b/ultravox/tools/ds_tool/ds_tool.py
@@ -59,7 +59,7 @@ def apply_jinja_template(
     except jinja2.TemplateError as e:
         print(f"Error rendering template: {e}")
         print(f"template: {template}")
-        print(f"sample keys: {list(sample.keys())}")
+        print(f"sample keys: {list(sample.keys())}, excluded keys: {exclude_fields}")
         raise ValueError(
             f"Template rendering failed. Make sure all keys in the template exist in the sample."
         ) from e


### PR DESCRIPTION
This PR adds a TimestampGeneration task to `ds_tool.py`. It uses [Montreal Forced Aligner (MFA)](https://montreal-forced-aligner.readthedocs.io/en/latest/getting_started.html).

The task adds a new column (e.g. "timestamps") that has word-level alignments in the form of:
```
[ {"start": float in seconds, "end": float in seconds, "text": first word str}, ... ]
```

Usage example:
```bash
# Install Conda environment named aligner
# and download english_mfa acoustic model and dictionary
just install_mfa

# Run ds_tool (make sure upload name is not the same as input dataset_name)
just ds_tool timestamp -d fixie-ai/common_voice_17_0 -S en --upload_name fixie-ai/cv_ts  \
    -m english_mfa -T "\"{{text_proc.format_asr_text(sentence)}}\""
```
