### PR TITLE
Break up datasets.py

### DIFF
--- a/ultravox/data/__init__.py
+++ b/ultravox/data/__init__.py
@@ -1,0 +1,16 @@
+from ultravox.data.datasets import *
+from ultravox.data.registry import *
+from ultravox.data.types import *
+
+__all__ = [
+    "SizedIterableDataset",
+    "EmptyDataset",
+    "InterleaveDataset",
+    "Range",
+    "Dataproc",
+    "VoiceDataset",
+    "VoiceDatasetArgs",
+    "VoiceSample",
+    "create_dataset",
+    "register_datasets",
+]

--- a/ultravox/data/__init__.py
+++ b/ultravox/data/__init__.py
@@ -1,3 +1,4 @@
+from ultravox.data.data_sample import *
 from ultravox.data.datasets import *
 from ultravox.data.registry import *
 from ultravox.data.types import *

--- a/ultravox/data/data_sample.py
+++ b/ultravox/data/data_sample.py
@@ -1,0 +1,111 @@
+import base64
+import dataclasses
+import io
+from typing import Any, Dict, List, Optional
+
+import librosa
+import numpy as np
+import soundfile as sf
+
+SAMPLE_RATE = 16000
+
+
+def audio_from_file(path: str) -> np.ndarray:
+    """Load audio from a file, converting to float32 PCM @ 16 kHz."""
+    audio, _ = librosa.load(path, sr=SAMPLE_RATE)
+    assert audio.dtype == np.float32
+    return audio
+
+
+def audio_from_buf(buf: bytes) -> np.ndarray:
+    """Load audio from a buffer, converting to float32 PCM @ 16 kHz."""
+    audio, _ = librosa.load(io.BytesIO(buf), sr=SAMPLE_RATE)
+    assert audio.dtype == np.float32
+    return audio
+
+
+def audio_to_wav(audio: np.ndarray, sample_rate: int = SAMPLE_RATE) -> bytes:
+    """Convert audio to WAV format, 16-bit PCM @ 16 kHz."""
+    assert audio.dtype == np.float32
+    with io.BytesIO() as buf:
+        sf.write(buf, audio, sample_rate, format="WAV", subtype="PCM_16")
+        return buf.getvalue()
+
+
+def audio_to_wav_base64(audio: np.ndarray, sample_rate: int = SAMPLE_RATE) -> str:
+    """Convert audio to a base64-encoded WAV file."""
+    return base64.b64encode(audio_to_wav(audio, sample_rate)).decode("utf-8")
+
+
+def audio_to_data_uri(audio: np.ndarray, sample_rate: int = SAMPLE_RATE) -> str:
+    """Convert audio to a data URI."""
+    return f"data:audio/wav;base64,{audio_to_wav_base64(audio, sample_rate)}"
+
+
+def messages_from_prompt(prompt: str) -> List[Dict[str, str]]:
+    return [{"role": "user", "content": prompt}]
+
+
+@dataclasses.dataclass
+class VoiceSample:
+    @staticmethod
+    def from_json(data: Dict[str, Any]) -> "VoiceSample":
+        """Convert from JSON format; audio is expected as base64ed WAV."""
+        bytes = base64.b64decode(data["audio"])
+        return VoiceSample(data["messages"], audio_from_buf(bytes))
+
+    @staticmethod
+    def from_prompt(prompt: str) -> "VoiceSample":
+        """Create a VoiceSample from a prompt only."""
+        return VoiceSample(messages_from_prompt(prompt), None)
+
+    @staticmethod
+    def from_prompt_and_file(prompt: str, path: str) -> "VoiceSample":
+        """Create a VoiceSample from a prompt and an audio file."""
+        return VoiceSample(messages_from_prompt(prompt), audio_from_file(path))
+
+    @staticmethod
+    def from_prompt_and_buf(prompt: str, buf: bytes) -> "VoiceSample":
+        """Create a VoiceSample from a prompt and an encoded audio buffer."""
+        return VoiceSample(messages_from_prompt(prompt), audio_from_buf(buf))
+
+    @staticmethod
+    def from_prompt_and_raw(
+        prompt: str, buf: np.ndarray, sample_rate: int
+    ) -> "VoiceSample":
+        """Create a VoiceSample from a prompt and raw audio data with sample rate."""
+        # Keep in native sample rate; we'll resample later if needed.
+        return VoiceSample(messages_from_prompt(prompt), buf, sample_rate)
+
+    def to_json(self) -> Dict[str, Any]:
+        """Convert to JSON format; audio is written as base64ed WAV."""
+        obj: Dict[str, Any] = {"messages": self.messages}
+        if self.audio is not None:
+            obj["audio"] = audio_to_wav_base64(self.audio, self.sample_rate)
+        return obj
+
+    def __post_init__(self):
+        """Ensure audio is float32 PCM."""
+        if self.audio is not None:
+            if self.audio.dtype == np.float64:
+                self.audio = self.audio.astype(np.float32)
+            elif self.audio.dtype == np.int16:
+                self.audio = self.audio.astype(np.float32) / np.float32(32768.0)
+            elif self.audio.dtype == np.int32:
+                self.audio = self.audio.astype(np.float32) / np.float32(2147483648.0)
+            assert (
+                self.audio.dtype == np.float32
+            ), f"Unexpected audio dtype: {self.audio.dtype}"
+            assert self.audio.ndim == 1, f"Unexpected audio shape: {self.audio.shape}"
+
+    def add_past_messages(self, past_messages: List[Dict[str, str]]):
+        self.messages = past_messages + self.messages
+
+    messages: List[Dict[str, str]]
+    """List of messages, each with a "role" and "content" field."""
+    audio: Optional[np.ndarray] = None
+    """Audio data as float32 PCM @ `sample_rate`."""
+    sample_rate: int = SAMPLE_RATE
+    """Audio sample rate in Hz."""
+    audio_transcript: Optional[str] = None
+    """For evaluations, the known transcript of the audio."""

--- a/ultravox/data/data_sample.py
+++ b/ultravox/data/data_sample.py
@@ -6,6 +6,7 @@ from typing import Any, Dict, List, Optional
 import librosa
 import numpy as np
 import soundfile as sf
+from numpy import typing as npt
 
 SAMPLE_RATE = 16000
 
@@ -103,7 +104,7 @@ class VoiceSample:
 
     messages: List[Dict[str, str]]
     """List of messages, each with a "role" and "content" field."""
-    audio: Optional[np.ndarray] = None
+    audio: Optional[npt.NDArray[np.float32]] = None
     """Audio data as float32 PCM @ `sample_rate`."""
     sample_rate: int = SAMPLE_RATE
     """Audio sample rate in Hz."""

--- a/ultravox/data/data_sample_test.py
+++ b/ultravox/data/data_sample_test.py
@@ -1,0 +1,84 @@
+from typing import Union
+
+import numpy as np
+import pytest
+
+from ultravox.data import data_sample
+
+
+def _create_sine_wave(
+    freq: int = 440,
+    duration: float = 1.0,
+    sample_rate: int = 16000,
+    amplitude: float = 0.1,
+    target_dtype: str = "float32",
+) -> Union[
+    np.typing.NDArray[np.float32],
+    np.typing.NDArray[np.float64],
+    np.typing.NDArray[np.int16],
+    np.typing.NDArray[np.int32],
+]:
+    t = np.arange(sample_rate * duration, dtype=np.float32) / sample_rate
+    wave = amplitude * np.sin(2 * np.pi * freq * t)
+    match target_dtype:
+        case "int16":
+            wave = np.int16(wave * 32767)
+        case "int32":
+            wave = np.int32(wave * 2147483647)
+        case "float32":
+            # Already float32, nothing needed.
+            pass
+        case "float64":
+            wave = wave.astype(np.float64)
+        case _:
+            raise ValueError(f"Unsupported dtype: {target_dtype}")
+    return wave
+
+
+def _create_and_validate_sample(target_dtype: str = "float32"):
+    # Create a sine wave at 440 Hz with a duration of 1.0 second, sampled at 16
+    # kHz, with an amplitude of 0.1, and the specified dtype.
+    array = _create_sine_wave(target_dtype=target_dtype)
+    sample = data_sample.VoiceSample.from_prompt_and_raw(
+        "Transcribe\n<|audio|>", array, 16000
+    )
+    assert sample.sample_rate == 16000
+    assert sample.audio is not None, "sample.audio should not be None"
+    assert len(sample.audio) == 16000
+    assert sample.audio.dtype == np.float32
+    assert sample.messages == [
+        {"role": "user", "content": "Transcribe\n<|audio|>"},
+    ]
+    # Serialize and deserialize the sample.
+    json = sample.to_json()
+    sample2 = data_sample.VoiceSample.from_json(json)
+    assert sample2.sample_rate == sample.sample_rate
+    assert sample2.audio is not None, "sample2.audio should not be None"
+    assert len(sample2.audio) == len(sample.audio)
+    assert sample2.audio.dtype == sample.audio.dtype
+    assert sample2.messages == sample.messages
+    assert np.allclose(sample2.audio, sample.audio, rtol=0.0001, atol=0.0001)
+
+
+def test_create_sample__int16():
+    _create_and_validate_sample("int16")
+
+
+def test_create_sample__int32():
+    _create_and_validate_sample("int32")
+
+
+def test_create_sample__float32():
+    _create_and_validate_sample("float32")
+
+
+def test_create_sample__float64():
+    _create_and_validate_sample("float64")
+
+
+def test_create_sample__raises_on_unsupported_dtype():
+    with pytest.raises(AssertionError):
+        array = np.ndarray(shape=(16000,), dtype=np.uint8)
+        _ = data_sample.VoiceSample.from_prompt_and_raw(
+            "Transcribe\n<|audio|>", array, 16000
+        )

--- a/ultravox/data/datasets.py
+++ b/ultravox/data/datasets.py
@@ -1,7 +1,5 @@
 import abc
 import dataclasses
-import enum
-import io
 import logging
 import os
 import tempfile

--- a/ultravox/data/datasets_test.py
+++ b/ultravox/data/datasets_test.py
@@ -1,4 +1,4 @@
-from typing import Optional, Union
+from typing import Optional
 
 import datasets as hf_datasets
 import numpy as np

--- a/ultravox/data/datasets_test.py
+++ b/ultravox/data/datasets_test.py
@@ -9,6 +9,8 @@ from torch.utils import data
 from transformers.feature_extraction_utils import BatchFeature
 
 from ultravox.data import datasets
+from ultravox.data import registry
+from ultravox.data import types
 
 
 class FakeSizedIterableDataset(datasets.SizedIterableDataset):
@@ -46,13 +48,11 @@ class FakeHuggingFaceIterableDataset(hf_datasets.IterableDataset):
 class FakeTranscribeDataset(datasets.VoiceDataset):
     """Fake version of our VoiceDataset."""
 
-    def __init__(self, n: int, args: Optional[datasets.VoiceDatasetArgs] = None):
-        super().__init__(
-            args or datasets.VoiceDatasetArgs(),
-        )
+    def __init__(self, n: int, args: Optional[types.VoiceDatasetArgs] = None):
+        super().__init__(args or types.VoiceDatasetArgs())
         self._init_dataset(FakeHuggingFaceIterableDataset(n), n)
 
-    def _get_sample(self, row: BatchFeature) -> Optional[datasets.VoiceSample]:
+    def _get_sample(self, row: BatchFeature) -> Optional[types.VoiceSample]:
         messages = self._make_messages("<|audio|>", row["text"])
         return self._make_sample(messages, np.zeros(256), row["text"])
 
@@ -63,11 +63,11 @@ class FakeGenericDataset(datasets.GenericDataset):
     def __init__(
         self,
         n: int,
-        config: datasets.DatasetConfig,
-        args: Optional[datasets.VoiceDatasetArgs] = None,
+        config: types.DatasetConfig,
+        args: Optional[types.VoiceDatasetArgs] = None,
     ):
         self._n = n
-        super().__init__(args or datasets.VoiceDatasetArgs(), config)
+        super().__init__(args or types.VoiceDatasetArgs(), config)
 
     def _load_hf_dataset(
         self,
@@ -201,7 +201,7 @@ def test_transcribe_dataset():
     ds = FakeTranscribeDataset(5)
     assert len(ds) == 5
     sample = next(iter(ds))
-    assert isinstance(sample, datasets.VoiceSample)
+    assert isinstance(sample, types.VoiceSample)
     assert sample.messages == [
         {"role": "user", "content": "<|audio|>"},
         {"role": "assistant", "content": "0"},
@@ -212,17 +212,17 @@ def test_transcribe_dataset():
 
 
 def test_dataset_config():
-    config = datasets.DatasetConfig(
+    config = types.DatasetConfig(
         name="fake_dataset",
         path="mock_path",
         splits=[
-            datasets.DatasetSplitConfig(name="clean", num_samples=5000),
-            datasets.DatasetSplitConfig(name="other", num_samples=10000),
-            datasets.DatasetSplitConfig(name="validation", num_samples=1000),
-            datasets.DatasetSplitConfig(
+            types.DatasetSplitConfig(name="clean", num_samples=5000),
+            types.DatasetSplitConfig(name="other", num_samples=10000),
+            types.DatasetSplitConfig(name="validation", num_samples=1000),
+            types.DatasetSplitConfig(
                 name="another_validation",
                 num_samples=1000,
-                split_type=datasets.DatasetSplit.VALIDATION,
+                split_type=types.DatasetSplit.VALIDATION,
             ),
         ],
     )
@@ -231,30 +231,30 @@ def test_dataset_config():
     assert len(config.splits) == 4
     assert config.splits[0].name == "clean"
     assert config.splits[0].num_samples == 5000
-    assert config.splits[0].split_type == datasets.DatasetSplit.TRAIN
+    assert config.splits[0].split_type == types.DatasetSplit.TRAIN
     assert config.splits[1].name == "other"
     assert config.splits[1].num_samples == 10000
-    assert config.splits[1].split_type == datasets.DatasetSplit.TRAIN
+    assert config.splits[1].split_type == types.DatasetSplit.TRAIN
     assert config.splits[2].name == "validation"
     assert config.splits[2].num_samples == 1000
-    assert config.splits[2].split_type == datasets.DatasetSplit.VALIDATION
+    assert config.splits[2].split_type == types.DatasetSplit.VALIDATION
     assert config.splits[3].name == "another_validation"
     assert config.splits[3].num_samples == 1000
-    assert config.splits[3].split_type == datasets.DatasetSplit.VALIDATION
+    assert config.splits[3].split_type == types.DatasetSplit.VALIDATION
 
 
 def test_dataset_config_serialization():
-    config = datasets.DatasetConfig(
+    config = types.DatasetConfig(
         name="fake_dataset",
         path="fake_path",
         splits=[
-            datasets.DatasetSplitConfig(name="clean", num_samples=5000),
-            datasets.DatasetSplitConfig(name="other", num_samples=10000),
+            types.DatasetSplitConfig(name="clean", num_samples=5000),
+            types.DatasetSplitConfig(name="other", num_samples=10000),
         ],
     )
     serialized = config.dumps_yaml()
-    deserialized = datasets.DatasetConfig.loads_yaml(serialized)
-    assert isinstance(deserialized, datasets.DatasetConfig)
+    deserialized = types.DatasetConfig.loads_yaml(serialized)
+    assert isinstance(deserialized, types.DatasetConfig)
     assert deserialized.name == "fake_dataset"
     assert deserialized.path == "fake_path"
     assert len(deserialized.splits) == 2
@@ -265,15 +265,15 @@ def test_dataset_config_serialization():
 
 
 def test_generic_dataset():
-    config = datasets.DatasetConfig(
+    config = types.DatasetConfig(
         name="fake_dataset",
         path="fake_path",
-        splits=[datasets.DatasetSplitConfig(name="fake", num_samples=5)],
+        splits=[types.DatasetSplitConfig(name="fake", num_samples=5)],
     )
     ds = FakeGenericDataset(5, config)
     assert len(ds) == 5
     sample = next(iter(ds))
-    assert isinstance(sample, datasets.VoiceSample)
+    assert isinstance(sample, types.VoiceSample)
     assert sample.messages == [
         {"role": "user", "content": "<|audio|>"},
         {"role": "assistant", "content": "0"},
@@ -284,10 +284,10 @@ def test_generic_dataset():
 
 
 def test_generic_dataset_custom_templates():
-    config = datasets.DatasetConfig(
+    config = types.DatasetConfig(
         name="fake_dataset",
         path="fake_path",
-        splits=[datasets.DatasetSplitConfig(name="fake", num_samples=5)],
+        splits=[types.DatasetSplitConfig(name="fake", num_samples=5)],
         user_template="Listen to the following and respond with 'xyzzy':\n<|audio|>",
         assistant_template="xyzzy",
         transcript_template="{{text}}",
@@ -295,7 +295,7 @@ def test_generic_dataset_custom_templates():
     ds = FakeGenericDataset(5, config)
     assert len(ds) == 5
     sample = next(iter(ds))
-    assert isinstance(sample, datasets.VoiceSample)
+    assert isinstance(sample, types.VoiceSample)
     assert sample.messages == [
         {
             "role": "user",
@@ -309,16 +309,16 @@ def test_generic_dataset_custom_templates():
 
 
 def test_generic_dataset_text_only():
-    config = datasets.DatasetConfig(
+    config = types.DatasetConfig(
         name="fake_dataset",
         path="fake_path",
-        splits=[datasets.DatasetSplitConfig(name="fake", num_samples=5)],
+        splits=[types.DatasetSplitConfig(name="fake", num_samples=5)],
         user_template="Transcribe\n<|audio|>",
     )
-    ds = FakeGenericDataset(5, config, datasets.VoiceDatasetArgs(include_audio=False))
+    ds = FakeGenericDataset(5, config, types.VoiceDatasetArgs(include_audio=False))
     assert len(ds) == 5
     sample = next(iter(ds))
-    assert isinstance(sample, datasets.VoiceSample)
+    assert isinstance(sample, types.VoiceSample)
     assert sample.messages == [
         {"role": "user", "content": 'Transcribe\n"0"'},
         {"role": "assistant", "content": "0"},
@@ -327,30 +327,30 @@ def test_generic_dataset_text_only():
 
 
 def test_generic_dataset_merge_configs():
-    base_config = datasets.DatasetConfig(
+    base_config = types.DatasetConfig(
         name="fake_base",
         path="fake_path",
-        splits=[datasets.DatasetSplitConfig(name="fake", num_samples=5)],
+        splits=[types.DatasetSplitConfig(name="fake", num_samples=5)],
     )
-    mid_config = datasets.DatasetConfig(
+    mid_config = types.DatasetConfig(
         name="fake_mid",
         base="fake_base",
         user_template="fake_user_template",
         user_template_args={"a": 1},
         transcript_template="fake_transcript_template",
     )
-    leaf_config = datasets.DatasetConfig(
+    leaf_config = types.DatasetConfig(
         name="fake_leaf",
         base="fake_mid",
         audio_field="fake_audio_field",
     )
-    config = datasets._merge_configs([base_config, mid_config, leaf_config])
+    config = registry._merge_configs([base_config, mid_config, leaf_config])
     assert config.name == "fake_leaf"
     assert config.base is None
     assert config.path == "fake_path"
     assert config.splits[0].name == "fake"
     assert config.splits[0].num_samples == 5
-    assert config.splits[0].split_type == datasets.DatasetSplit.TRAIN
+    assert config.splits[0].split_type == types.DatasetSplit.TRAIN
     assert config.user_template == "fake_user_template"
     assert config.user_template_args == {"a": 1}
     assert config.assistant_template == "{{text}}"  # the default
@@ -359,10 +359,10 @@ def test_generic_dataset_merge_configs():
 
 
 def test_generic_dataset_length_mismatch():
-    config = datasets.DatasetConfig(
+    config = types.DatasetConfig(
         name="fake_dataset",
         path="fake_path",
-        splits=[datasets.DatasetSplitConfig(name="fake", num_samples=5)],
+        splits=[types.DatasetSplitConfig(name="fake", num_samples=5)],
     )
     ds = FakeGenericDataset(10, config)
     assert len(ds) == 5
@@ -371,10 +371,10 @@ def test_generic_dataset_length_mismatch():
     with pytest.warns(UserWarning, match=pattern):
         list(ds)
 
-    config = datasets.DatasetConfig(
+    config = types.DatasetConfig(
         name="fake_dataset",
         path="fake_path",
-        splits=[datasets.DatasetSplitConfig(name="fake", num_samples=10)],
+        splits=[types.DatasetSplitConfig(name="fake", num_samples=10)],
     )
     ds = FakeGenericDataset(5, config)
     assert len(ds) == 10
@@ -384,18 +384,18 @@ def test_generic_dataset_length_mismatch():
 
 
 def test_generic_dataset_multiple_splits():
-    config = datasets.DatasetConfig(
+    config = types.DatasetConfig(
         name="fake_dataset",
         path="fake_path",
         splits=[
-            datasets.DatasetSplitConfig(name="train", num_samples=90),
-            datasets.DatasetSplitConfig(name="validation", num_samples=10),
+            types.DatasetSplitConfig(name="train", num_samples=90),
+            types.DatasetSplitConfig(name="validation", num_samples=10),
         ],
     )
     ds = FakeGenericDataset(100, config)
     assert len(ds) == 90
     ds = FakeGenericDataset(
-        100, config, datasets.VoiceDatasetArgs(split=datasets.DatasetSplit.VALIDATION)
+        100, config, types.VoiceDatasetArgs(split=types.DatasetSplit.VALIDATION)
     )
     assert len(ds) == 10
 
@@ -433,7 +433,7 @@ def _create_and_validate_sample(target_dtype: str = "float32"):
     # Create a sine wave at 440 Hz with a duration of 1.0 second, sampled at 16
     # kHz, with an amplitude of 0.1, and the specified dtype.
     array = _create_sine_wave(target_dtype=target_dtype)
-    sample = datasets.VoiceSample.from_prompt_and_raw(
+    sample = types.VoiceSample.from_prompt_and_raw(
         "Transcribe\n<|audio|>", array, 16000
     )
     assert sample.sample_rate == 16000
@@ -445,7 +445,7 @@ def _create_and_validate_sample(target_dtype: str = "float32"):
     ]
     # Serialize and deserialize the sample.
     json = sample.to_json()
-    sample2 = datasets.VoiceSample.from_json(json)
+    sample2 = types.VoiceSample.from_json(json)
     assert sample2.sample_rate == sample.sample_rate
     assert sample2.audio is not None, "sample2.audio should not be None"
     assert len(sample2.audio) == len(sample.audio)
@@ -473,9 +473,7 @@ def test_create_sample__float64():
 def test_create_sample__raises_on_unsupported_dtype():
     with pytest.raises(AssertionError):
         array = np.ndarray(shape=(16000,), dtype=np.uint8)
-        _ = datasets.VoiceSample.from_prompt_and_raw(
-            "Transcribe\n<|audio|>", array, 16000
-        )
+        _ = types.VoiceSample.from_prompt_and_raw("Transcribe\n<|audio|>", array, 16000)
 
 
 def test_get_messages():

--- a/ultravox/data/registry.py
+++ b/ultravox/data/registry.py
@@ -1,0 +1,397 @@
+import dataclasses
+from typing import Dict, List, Optional
+
+from ultravox.data import datasets
+from ultravox.data import types
+
+CONTINUATION_USER_TEMPLATE = f"Continue the following text using less than 50 words:\n\n{types.AUDIO_PLACEHOLDER}"
+CONTINUATION_ASSISTANT_TEMPLATE = "{{continuation}}"
+TRANSCRIPTION_USER_TEMPLATE = f"Transcribe\n{types.AUDIO_PLACEHOLDER}"
+
+BOOLQ_CONFIG = types.DatasetConfig(
+    name="boolq",
+    path="fixie-ai/boolq-audio",
+    splits=[
+        types.DatasetSplitConfig(name="train", num_samples=10000),
+        types.DatasetSplitConfig(name="validation", num_samples=1000),
+    ],
+    user_template="{{passage}}\n\n{AUDIO_PLACEHOLDER}",
+    assistant_template="{{'True' if answer else 'False'}}",
+    transcript_template="{{question}}",
+)
+
+CV_BASE_CONFIG = types.DatasetConfig(
+    name="commonvoice",
+    path="fixie-ai/common_voice_17_0",
+    assistant_template="{{sentence}}",
+    transcript_template="{{sentence}}",
+)
+
+CV_EN_CONFIG = types.DatasetConfig(
+    name="commonvoice-en",
+    base="commonvoice",
+    subset="en",
+    splits=[types.DatasetSplitConfig(name="train", num_samples=1_101_170)],
+)
+
+CV_AR_CONFIG = types.DatasetConfig(
+    name="commonvoice-ar",
+    base="commonvoice",
+    subset="ar",
+    splits=[types.DatasetSplitConfig(name="train", num_samples=28_369)],
+)
+
+CV_DE_CONFIG = types.DatasetConfig(
+    name="commonvoice-de",
+    base="commonvoice",
+    subset="de",
+    splits=[types.DatasetSplitConfig(name="train", num_samples=589_100)],
+)
+
+CV_ES_CONFIG = types.DatasetConfig(
+    name="commonvoice-es",
+    base="commonvoice",
+    subset="es",
+    splits=[types.DatasetSplitConfig(name="train", num_samples=336_846)],
+)
+
+CV_FR_CONFIG = types.DatasetConfig(
+    name="commonvoice-fr",
+    base="commonvoice",
+    subset="fr",
+    splits=[types.DatasetSplitConfig(name="train", num_samples=558_054)],
+)
+
+CV_IT_CONFIG = types.DatasetConfig(
+    name="commonvoice-it",
+    base="commonvoice",
+    subset="it",
+    splits=[types.DatasetSplitConfig(name="train", num_samples=169_771)],
+)
+
+CV_JA_CONFIG = types.DatasetConfig(
+    name="commonvoice-ja",
+    base="commonvoice",
+    subset="ja",
+    splits=[types.DatasetSplitConfig(name="train", num_samples=10_039)],
+)
+
+CV_PT_CONFIG = types.DatasetConfig(
+    name="commonvoice-pt",
+    base="commonvoice",
+    subset="pt",
+    splits=[types.DatasetSplitConfig(name="train", num_samples=21_968)],
+)
+
+CV_RU_CONFIG = types.DatasetConfig(
+    name="commonvoice-ru",
+    base="commonvoice",
+    subset="ru",
+    splits=[types.DatasetSplitConfig(name="train", num_samples=26_377)],
+)
+
+GS_XL_CONFIG = types.DatasetConfig(
+    name="gigaspeech",
+    path="speechcolab/gigaspeech",
+    subset="xl",
+    splits=[
+        types.DatasetSplitConfig(name="train", num_samples=1_000_000),
+        types.DatasetSplitConfig(name="validation", num_samples=10_000),
+    ],
+    assistant_template="{{text_proc.format_asr_text(text)}}",
+    transcript_template="{{text_proc.format_asr_text(text)}}",
+)
+
+LS_BASE_CONFIG = types.DatasetConfig(
+    name="librispeech",
+    path="fixie-ai/librispeech_asr",
+    assistant_template="{{text_proc.format_asr_text(text)}}",
+    transcript_template="{{text_proc.format_asr_text(text)}}",
+)
+
+LS_CLEAN_CONFIG = types.DatasetConfig(
+    name="librispeech-clean",
+    base="librispeech",
+    subset="clean",
+    splits=[
+        types.DatasetSplitConfig(name="train.100", num_samples=28_539),
+        types.DatasetSplitConfig(name="train.360", num_samples=104_014),
+    ],
+)
+
+LS_OTHER_CONFIG = types.DatasetConfig(
+    name="librispeech-other",
+    base="librispeech",
+    subset="other",
+    splits=[
+        types.DatasetSplitConfig(name="train.500", num_samples=148_688),
+    ],
+)
+
+PS_CLEAN_CONFIG = types.DatasetConfig(
+    name="peoplespeech",
+    path="fixie-ai/peoples_speech",
+    subset="clean",
+    splits=[
+        types.DatasetSplitConfig(name="train", num_samples=1_000_000),
+        types.DatasetSplitConfig(name="validation", num_samples=10_000),
+    ],
+)
+
+# SODA_CONFIG = types.DatasetConfig(
+#     name="soda",
+#     path="fixie-ai/soda-audio",
+#     splits=[
+#         types.DatasetSplitConfig(name="train", num_samples=1_000_000),
+#         types.DatasetSplitConfig(name="validation", num_samples=10_000),
+#     ],
+#     # Need way to specify message history.
+#     audio_field="audio_second_last_turn",
+#     assistant_template="{{alt_last_turn}}",
+#     transcript_template="{{turns[-2]}}",
+# )
+
+VP_EN_CONFIG = types.DatasetConfig(
+    name="voxpopuli-en",
+    path="facebook/voxpopuli",
+    subset="en",
+    splits=[
+        types.DatasetSplitConfig(name="train", num_samples=1_000_000),
+        types.DatasetSplitConfig(name="validation", num_samples=10_000),
+    ],
+    assistant_template="{{raw_text}}",
+    transcript_template="{{raw_text}}",
+)
+
+CV_EN_TRANS_CONFIG = types.DatasetConfig(
+    name="commonvoice-en-transcription",
+    base="commonvoice-en",
+    user_template=TRANSCRIPTION_USER_TEMPLATE,
+)
+CV_AR_TRANS_CONFIG = types.DatasetConfig(
+    name="commonvoice-ar-transcription",
+    base="commonvoice-ar",
+    user_template=TRANSCRIPTION_USER_TEMPLATE,
+)
+CV_DE_TRANS_CONFIG = types.DatasetConfig(
+    name="commonvoice-de-transcription",
+    base="commonvoice-de",
+    user_template=TRANSCRIPTION_USER_TEMPLATE,
+)
+CV_ES_TRANS_CONFIG = types.DatasetConfig(
+    name="commonvoice-es-transcription",
+    base="commonvoice-es",
+    user_template=TRANSCRIPTION_USER_TEMPLATE,
+)
+CV_FR_TRANS_CONFIG = types.DatasetConfig(
+    name="commonvoice-fr-transcription",
+    base="commonvoice-fr",
+    user_template=TRANSCRIPTION_USER_TEMPLATE,
+)
+CV_IT_TRANS_CONFIG = types.DatasetConfig(
+    name="commonvoice-it-transcription",
+    base="commonvoice-it",
+    user_template=TRANSCRIPTION_USER_TEMPLATE,
+)
+CV_JA_TRANS_CONFIG = types.DatasetConfig(
+    name="commonvoice-ja-transcription",
+    base="commonvoice-ja",
+    user_template=TRANSCRIPTION_USER_TEMPLATE,
+)
+CV_PT_TRANS_CONFIG = types.DatasetConfig(
+    name="commonvoice-pt-transcription",
+    base="commonvoice-pt",
+    user_template=TRANSCRIPTION_USER_TEMPLATE,
+)
+CV_RU_TRANS_CONFIG = types.DatasetConfig(
+    name="commonvoice-ru-transcription",
+    base="commonvoice-ru",
+    user_template=TRANSCRIPTION_USER_TEMPLATE,
+)
+
+LS_CLEAN_TRANS_CONFIG = types.DatasetConfig(
+    name="librispeech-clean-transcription",
+    base="librispeech-clean",
+    user_template=TRANSCRIPTION_USER_TEMPLATE,
+)
+LS_OTHER_TRANS_CONFIG = types.DatasetConfig(
+    name="librispeech-other-transcription",
+    base="librispeech-other",
+    user_template=TRANSCRIPTION_USER_TEMPLATE,
+)
+
+PS_CLEAN_TRANS_CONFIG = types.DatasetConfig(
+    name="peoplespeech-clean-transcription",
+    base="peoplespeech",
+    user_template=TRANSCRIPTION_USER_TEMPLATE,
+)
+
+CV_EN_CONT_CONFIG = types.DatasetConfig(
+    name="commonvoice-en-continuation",
+    base="commonvoice-en",
+    user_template=CONTINUATION_USER_TEMPLATE,
+    assistant_template=CONTINUATION_ASSISTANT_TEMPLATE,
+)
+CV_AR_CONT_CONFIG = types.DatasetConfig(
+    name="commonvoice-ar-continuation",
+    base="commonvoice-ar",
+    user_template=CONTINUATION_USER_TEMPLATE,
+    assistant_template=CONTINUATION_ASSISTANT_TEMPLATE,
+)
+CV_DE_CONT_CONFIG = types.DatasetConfig(
+    name="commonvoice-de-continuation",
+    base="commonvoice-de",
+    user_template=CONTINUATION_USER_TEMPLATE,
+    assistant_template=CONTINUATION_ASSISTANT_TEMPLATE,
+)
+CV_ES_CONT_CONFIG = types.DatasetConfig(
+    name="commonvoice-es-continuation",
+    base="commonvoice-es",
+    user_template=CONTINUATION_USER_TEMPLATE,
+    assistant_template=CONTINUATION_ASSISTANT_TEMPLATE,
+)
+CV_FR_CONT_CONFIG = types.DatasetConfig(
+    name="commonvoice-fr-continuation",
+    base="commonvoice-fr",
+    user_template=CONTINUATION_USER_TEMPLATE,
+    assistant_template=CONTINUATION_ASSISTANT_TEMPLATE,
+)
+CV_IT_CONT_CONFIG = types.DatasetConfig(
+    name="commonvoice-it-continuation",
+    base="commonvoice-it",
+    user_template=CONTINUATION_USER_TEMPLATE,
+    assistant_template=CONTINUATION_ASSISTANT_TEMPLATE,
+)
+CV_JA_CONT_CONFIG = types.DatasetConfig(
+    name="commonvoice-ja-continuation",
+    base="commonvoice-ja",
+    user_template=CONTINUATION_USER_TEMPLATE,
+    assistant_template=CONTINUATION_ASSISTANT_TEMPLATE,
+)
+CV_PT_CONT_CONFIG = types.DatasetConfig(
+    name="commonvoice-pt-continuation",
+    base="commonvoice-pt",
+    user_template=CONTINUATION_USER_TEMPLATE,
+    assistant_template=CONTINUATION_ASSISTANT_TEMPLATE,
+)
+CV_RU_CONT_CONFIG = types.DatasetConfig(
+    name="commonvoice-ru-continuation",
+    base="commonvoice-ru",
+    user_template=CONTINUATION_USER_TEMPLATE,
+    assistant_template=CONTINUATION_ASSISTANT_TEMPLATE,
+)
+
+LS_CLEAN_CONT_CONFIG = types.DatasetConfig(
+    name="librispeech-clean-continuation",
+    base="librispeech-clean",
+    user_template=CONTINUATION_USER_TEMPLATE,
+    assistant_template=CONTINUATION_ASSISTANT_TEMPLATE,
+)
+LS_OTHER_CONT_CONFIG = types.DatasetConfig(
+    name="librispeech-other-continuation",
+    base="librispeech-other",
+    user_template=CONTINUATION_USER_TEMPLATE,
+    assistant_template=CONTINUATION_ASSISTANT_TEMPLATE,
+)
+
+PS_CLEAN_CONT_CONFIG = types.DatasetConfig(
+    name="peoplespeech-clean-continuation",
+    base="peoplespeech",
+    user_template=CONTINUATION_USER_TEMPLATE,
+    assistant_template=CONTINUATION_ASSISTANT_TEMPLATE,
+)
+
+INTERNAL_DATASETS = [
+    BOOLQ_CONFIG,
+    CV_BASE_CONFIG,
+    CV_EN_CONFIG,
+    CV_AR_CONFIG,
+    CV_DE_CONFIG,
+    CV_ES_CONFIG,
+    CV_FR_CONFIG,
+    CV_IT_CONFIG,
+    CV_JA_CONFIG,
+    CV_PT_CONFIG,
+    CV_RU_CONFIG,
+    CV_EN_TRANS_CONFIG,
+    CV_AR_TRANS_CONFIG,
+    CV_DE_TRANS_CONFIG,
+    CV_ES_TRANS_CONFIG,
+    CV_FR_TRANS_CONFIG,
+    CV_IT_TRANS_CONFIG,
+    CV_JA_TRANS_CONFIG,
+    CV_PT_TRANS_CONFIG,
+    CV_RU_TRANS_CONFIG,
+    CV_EN_CONT_CONFIG,
+    CV_AR_CONT_CONFIG,
+    CV_DE_CONT_CONFIG,
+    CV_ES_CONT_CONFIG,
+    CV_FR_CONT_CONFIG,
+    CV_IT_CONT_CONFIG,
+    CV_JA_CONT_CONFIG,
+    CV_PT_CONT_CONFIG,
+    CV_RU_CONT_CONFIG,
+    GS_XL_CONFIG,
+    LS_BASE_CONFIG,
+    LS_CLEAN_CONFIG,
+    LS_OTHER_CONFIG,
+    LS_CLEAN_TRANS_CONFIG,
+    LS_OTHER_TRANS_CONFIG,
+    LS_CLEAN_CONT_CONFIG,
+    LS_OTHER_CONT_CONFIG,
+    PS_CLEAN_CONFIG,
+    PS_CLEAN_TRANS_CONFIG,
+    PS_CLEAN_CONT_CONFIG,
+    VP_EN_CONFIG,
+]
+DATASET_MAP: Dict[str, types.DatasetConfig] = {}
+
+
+def register_datasets(data_sets: List[types.DatasetConfig]):
+    for config in data_sets:
+        name = config.name
+        assert name not in DATASET_MAP, f"Dataset {name} already registered"
+        DATASET_MAP[name] = config
+
+
+def unregister_datasets(datasets: List[str]):
+    for name in datasets:
+        del DATASET_MAP[name]
+
+
+def _merge_configs(configs: List[types.DatasetConfig]) -> types.DatasetConfig:
+    merged_config = dataclasses.replace(configs[0])
+    for config in configs[1:]:
+        for field in dataclasses.fields(config):
+            value = getattr(config, field.name)
+            if field.name != "base" and value is not None:
+                merged_config = dataclasses.replace(
+                    merged_config, **{field.name: value}
+                )
+    return merged_config
+
+
+def create_dataset(
+    name: str, args: types.VoiceDatasetArgs
+) -> datasets.SizedIterableDataset:
+    if name == "dummy":
+        return datasets.LibriSpeechDummyDataset(args)
+    assert name in DATASET_MAP, f"Unknown dataset: {name}"
+    # Make a list of configs from root->base.
+    configs: List[types.DatasetConfig] = []
+    temp: Optional[str] = name
+    while temp:
+        config = DATASET_MAP[temp]
+        configs.insert(0, config)
+        temp = config.base
+    # Set the root config, and then apply any non-None overrides from the subclasses.
+    merged_config = _merge_configs(configs)
+    # Sanity check.
+    if not merged_config.path:
+        raise ValueError(f"Dataset {name} has no path")
+    if not merged_config.splits:
+        raise ValueError(f"Dataset {name} has no splits")
+    return datasets.GenericDataset(args, merged_config)
+
+
+register_datasets(INTERNAL_DATASETS)

--- a/ultravox/data/registry.py
+++ b/ultravox/data/registry.py
@@ -151,16 +151,21 @@ PS_CLEAN_CONFIG = types.DatasetConfig(
 #     transcript_template="{{turns[-2]}}",
 # )
 
+VP_BASE_CONFIG = types.DatasetConfig(
+    name="voxpopuli",
+    path="facebook/voxpopuli",
+    assistant_template="{{raw_text}}",
+    transcript_template="{{raw_text}}",
+)
+
 VP_EN_CONFIG = types.DatasetConfig(
     name="voxpopuli-en",
-    path="facebook/voxpopuli",
+    base="voxpopuli",
     subset="en",
     splits=[
         types.DatasetSplitConfig(name="train", num_samples=1_000_000),
         types.DatasetSplitConfig(name="validation", num_samples=10_000),
     ],
-    assistant_template="{{raw_text}}",
-    transcript_template="{{raw_text}}",
 )
 
 CV_EN_TRANS_CONFIG = types.DatasetConfig(

--- a/ultravox/data/types.py
+++ b/ultravox/data/types.py
@@ -1,0 +1,206 @@
+import base64
+import dataclasses
+import enum
+import io
+from typing import Any, Dict, List, Optional
+
+import librosa
+import numpy as np
+import soundfile as sf
+from simple_parsing import helpers
+
+AUDIO_PLACEHOLDER = "<|audio|>"
+SAMPLE_RATE = 16000
+
+
+class DatasetSplit(str, enum.Enum):
+    TRAIN = "train"
+    VALIDATION = "validation"
+
+
+@dataclasses.dataclass
+class VoiceDatasetArgs:
+    """Global arguments for voice datasets."""
+
+    batch_size: int = 4
+    """Batch size for train, eval, or validation."""
+    include_audio: bool = True
+    """Whether to include audio in the samples."""
+    shuffle: bool = False
+    """Whether to shuffle the dataset."""
+    shuffle_seed: int = 42
+    """Seed for shuffling the dataset."""
+    max_audio_duration_secs: Optional[float] = None
+    """Whether to skip samples with audio longer than this duration."""
+    split: DatasetSplit = DatasetSplit.TRAIN
+    """Which split of the dataset to use."""
+
+    def __post_init__(self):
+        if isinstance(self.split, str):
+            self.split = DatasetSplit(self.split.lower())
+
+
+@dataclasses.dataclass
+class DatasetSplitConfig(helpers.Serializable):
+    name: str
+    """Name of the split."""
+    num_samples: int
+    """Number of samples in the split"""
+    split_type: DatasetSplit = DatasetSplit.TRAIN
+    """Type of split, i.e., train or validation."""
+
+    def __post_init__(self):
+        """Automatically set is_validation if it's a validation split."""
+        if self.name == "test":
+            self.split_type = DatasetSplit.TEST
+        elif self.name == "validation":
+            self.split_type = DatasetSplit.VALIDATION
+
+
+@dataclasses.dataclass
+class DatasetConfig(helpers.Serializable):
+    # Note that subclasses can override any of these fields, but they currently can't
+    # extend structured fields like splits or user_template_args.
+    # See _merge_configs below for the current implementation.
+    name: str
+    """Name of the dataset."""
+    base: Optional[str] = None
+    """Base dataset config to inherit from."""
+    path: Optional[str] = None
+    """Directory of the dataset, or huggingface dataset name; must be set for "generic" datasets. If not set, it is automatically inferred for predefined dataset types."""
+    subset: Optional[str] = None
+    """Name of the dataset, or huggingface dataset config/subset name."""
+    splits: Optional[List[DatasetSplitConfig]] = None
+    """List of splits to use, e.g. [{"name": "train", "num_samples": 1000}, {"name": "validation", "num_samples": 100}]."""
+    user_template: Optional[str] = None
+    """Template for the user message."""
+    user_template_args: Optional[Dict[str, str]] = None
+    """Optional arguments (e.g., target language) for the user template."""
+    assistant_template: Optional[str] = None
+    """Template for the assistant message."""
+    transcript_template: Optional[str] = None
+    """Template for the transcript."""
+    audio_field: Optional[str] = None
+    """Field in the dataset that contains the audio, use None if the dataset does not contain audio."""
+    use_mds: Optional[bool] = None
+    """Set to True to load the dataset from GCP (using MDS) instead of Hugging Face."""
+    mds_batch_size: Optional[int] = None
+    """Batch size for the dataset when using MDS."""
+
+    def __post_init__(self):
+        """Set defaults only if this is a root config, so that said defaults in a subclass don't act as overrides."""
+        DEFAULTS = {
+            "splits": [],
+            "user_template": AUDIO_PLACEHOLDER,
+            "user_template_args": {},
+            "assistant_template": "{{text}}",
+            "transcript_template": "{{text}}",
+            "audio_field": "audio",
+            "use_mds": False,
+            "mds_batch_size": 32,
+        }
+        if self.base is None:
+            for attr, default_value in DEFAULTS.items():
+                if getattr(self, attr) is None:
+                    setattr(self, attr, default_value)
+
+
+def audio_from_file(path: str) -> np.ndarray:
+    """Load audio from a file, converting to float32 PCM @ 16 kHz."""
+    audio, _ = librosa.load(path, sr=SAMPLE_RATE)
+    assert audio.dtype == np.float32
+    return audio
+
+
+def audio_from_buf(buf: bytes) -> np.ndarray:
+    """Load audio from a buffer, converting to float32 PCM @ 16 kHz."""
+    audio, _ = librosa.load(io.BytesIO(buf), sr=SAMPLE_RATE)
+    assert audio.dtype == np.float32
+    return audio
+
+
+def audio_to_wav(audio: np.ndarray, sample_rate: int = SAMPLE_RATE) -> bytes:
+    """Convert audio to WAV format, 16-bit PCM @ 16 kHz."""
+    assert audio.dtype == np.float32
+    with io.BytesIO() as buf:
+        sf.write(buf, audio, sample_rate, format="WAV", subtype="PCM_16")
+        return buf.getvalue()
+
+
+def audio_to_wav_base64(audio: np.ndarray, sample_rate: int = SAMPLE_RATE) -> str:
+    """Convert audio to a base64-encoded WAV file."""
+    return base64.b64encode(audio_to_wav(audio, sample_rate)).decode("utf-8")
+
+
+def audio_to_data_uri(audio: np.ndarray, sample_rate: int = SAMPLE_RATE) -> str:
+    """Convert audio to a data URI."""
+    return f"data:audio/wav;base64,{audio_to_wav_base64(audio, sample_rate)}"
+
+
+def messages_from_prompt(prompt: str) -> List[Dict[str, str]]:
+    return [{"role": "user", "content": prompt}]
+
+
+@dataclasses.dataclass
+class VoiceSample:
+    @staticmethod
+    def from_json(data: Dict[str, Any]) -> "VoiceSample":
+        """Convert from JSON format; audio is expected as base64ed WAV."""
+        bytes = base64.b64decode(data["audio"])
+        return VoiceSample(data["messages"], audio_from_buf(bytes))
+
+    @staticmethod
+    def from_prompt(prompt: str) -> "VoiceSample":
+        """Create a VoiceSample from a prompt only."""
+        return VoiceSample(messages_from_prompt(prompt), None)
+
+    @staticmethod
+    def from_prompt_and_file(prompt: str, path: str) -> "VoiceSample":
+        """Create a VoiceSample from a prompt and an audio file."""
+        return VoiceSample(messages_from_prompt(prompt), audio_from_file(path))
+
+    @staticmethod
+    def from_prompt_and_buf(prompt: str, buf: bytes) -> "VoiceSample":
+        """Create a VoiceSample from a prompt and an encoded audio buffer."""
+        return VoiceSample(messages_from_prompt(prompt), audio_from_buf(buf))
+
+    @staticmethod
+    def from_prompt_and_raw(
+        prompt: str, buf: np.ndarray, sample_rate: int
+    ) -> "VoiceSample":
+        """Create a VoiceSample from a prompt and raw audio data with sample rate."""
+        # Keep in native sample rate; we'll resample later if needed.
+        return VoiceSample(messages_from_prompt(prompt), buf, sample_rate)
+
+    def to_json(self) -> Dict[str, Any]:
+        """Convert to JSON format; audio is written as base64ed WAV."""
+        obj: Dict[str, Any] = {"messages": self.messages}
+        if self.audio is not None:
+            obj["audio"] = audio_to_wav_base64(self.audio, self.sample_rate)
+        return obj
+
+    def __post_init__(self):
+        """Ensure audio is float32 PCM."""
+        if self.audio is not None:
+            if self.audio.dtype == np.float64:
+                self.audio = self.audio.astype(np.float32)
+            elif self.audio.dtype == np.int16:
+                self.audio = self.audio.astype(np.float32) / np.float32(32768.0)
+            elif self.audio.dtype == np.int32:
+                self.audio = self.audio.astype(np.float32) / np.float32(2147483648.0)
+            assert (
+                self.audio.dtype == np.float32
+            ), f"Unexpected audio dtype: {self.audio.dtype}"
+            assert self.audio.ndim == 1, f"Unexpected audio shape: {self.audio.shape}"
+
+    def add_past_messages(self, past_messages: List[Dict[str, str]]):
+        self.messages = past_messages + self.messages
+
+    messages: List[Dict[str, str]]
+    """List of messages, each with a "role" and "content" field."""
+    audio: Optional[np.typing.NDArray[np.float32]] = None
+    """Audio data as float32 PCM @ `sample_rate`."""
+    sample_rate: int = SAMPLE_RATE
+    """Audio sample rate in Hz."""
+    audio_transcript: Optional[str] = None
+    """For evaluations, the known transcript of the audio."""

--- a/ultravox/data/types.py
+++ b/ultravox/data/types.py
@@ -1,16 +1,10 @@
-import base64
 import dataclasses
 import enum
-import io
-from typing import Any, Dict, List, Optional
+from typing import Dict, List, Optional
 
-import librosa
-import numpy as np
-import soundfile as sf
 from simple_parsing import helpers
 
 AUDIO_PLACEHOLDER = "<|audio|>"
-SAMPLE_RATE = 16000
 
 
 class DatasetSplit(str, enum.Enum):
@@ -103,104 +97,3 @@ class DatasetConfig(helpers.Serializable):
             for attr, default_value in DEFAULTS.items():
                 if getattr(self, attr) is None:
                     setattr(self, attr, default_value)
-
-
-def audio_from_file(path: str) -> np.ndarray:
-    """Load audio from a file, converting to float32 PCM @ 16 kHz."""
-    audio, _ = librosa.load(path, sr=SAMPLE_RATE)
-    assert audio.dtype == np.float32
-    return audio
-
-
-def audio_from_buf(buf: bytes) -> np.ndarray:
-    """Load audio from a buffer, converting to float32 PCM @ 16 kHz."""
-    audio, _ = librosa.load(io.BytesIO(buf), sr=SAMPLE_RATE)
-    assert audio.dtype == np.float32
-    return audio
-
-
-def audio_to_wav(audio: np.ndarray, sample_rate: int = SAMPLE_RATE) -> bytes:
-    """Convert audio to WAV format, 16-bit PCM @ 16 kHz."""
-    assert audio.dtype == np.float32
-    with io.BytesIO() as buf:
-        sf.write(buf, audio, sample_rate, format="WAV", subtype="PCM_16")
-        return buf.getvalue()
-
-
-def audio_to_wav_base64(audio: np.ndarray, sample_rate: int = SAMPLE_RATE) -> str:
-    """Convert audio to a base64-encoded WAV file."""
-    return base64.b64encode(audio_to_wav(audio, sample_rate)).decode("utf-8")
-
-
-def audio_to_data_uri(audio: np.ndarray, sample_rate: int = SAMPLE_RATE) -> str:
-    """Convert audio to a data URI."""
-    return f"data:audio/wav;base64,{audio_to_wav_base64(audio, sample_rate)}"
-
-
-def messages_from_prompt(prompt: str) -> List[Dict[str, str]]:
-    return [{"role": "user", "content": prompt}]
-
-
-@dataclasses.dataclass
-class VoiceSample:
-    @staticmethod
-    def from_json(data: Dict[str, Any]) -> "VoiceSample":
-        """Convert from JSON format; audio is expected as base64ed WAV."""
-        bytes = base64.b64decode(data["audio"])
-        return VoiceSample(data["messages"], audio_from_buf(bytes))
-
-    @staticmethod
-    def from_prompt(prompt: str) -> "VoiceSample":
-        """Create a VoiceSample from a prompt only."""
-        return VoiceSample(messages_from_prompt(prompt), None)
-
-    @staticmethod
-    def from_prompt_and_file(prompt: str, path: str) -> "VoiceSample":
-        """Create a VoiceSample from a prompt and an audio file."""
-        return VoiceSample(messages_from_prompt(prompt), audio_from_file(path))
-
-    @staticmethod
-    def from_prompt_and_buf(prompt: str, buf: bytes) -> "VoiceSample":
-        """Create a VoiceSample from a prompt and an encoded audio buffer."""
-        return VoiceSample(messages_from_prompt(prompt), audio_from_buf(buf))
-
-    @staticmethod
-    def from_prompt_and_raw(
-        prompt: str, buf: np.ndarray, sample_rate: int
-    ) -> "VoiceSample":
-        """Create a VoiceSample from a prompt and raw audio data with sample rate."""
-        # Keep in native sample rate; we'll resample later if needed.
-        return VoiceSample(messages_from_prompt(prompt), buf, sample_rate)
-
-    def to_json(self) -> Dict[str, Any]:
-        """Convert to JSON format; audio is written as base64ed WAV."""
-        obj: Dict[str, Any] = {"messages": self.messages}
-        if self.audio is not None:
-            obj["audio"] = audio_to_wav_base64(self.audio, self.sample_rate)
-        return obj
-
-    def __post_init__(self):
-        """Ensure audio is float32 PCM."""
-        if self.audio is not None:
-            if self.audio.dtype == np.float64:
-                self.audio = self.audio.astype(np.float32)
-            elif self.audio.dtype == np.int16:
-                self.audio = self.audio.astype(np.float32) / np.float32(32768.0)
-            elif self.audio.dtype == np.int32:
-                self.audio = self.audio.astype(np.float32) / np.float32(2147483648.0)
-            assert (
-                self.audio.dtype == np.float32
-            ), f"Unexpected audio dtype: {self.audio.dtype}"
-            assert self.audio.ndim == 1, f"Unexpected audio shape: {self.audio.shape}"
-
-    def add_past_messages(self, past_messages: List[Dict[str, str]]):
-        self.messages = past_messages + self.messages
-
-    messages: List[Dict[str, str]]
-    """List of messages, each with a "role" and "content" field."""
-    audio: Optional[np.typing.NDArray[np.float32]] = None
-    """Audio data as float32 PCM @ `sample_rate`."""
-    sample_rate: int = SAMPLE_RATE
-    """Audio sample rate in Hz."""
-    audio_transcript: Optional[str] = None
-    """For evaluations, the known transcript of the audio."""

--- a/ultravox/inference/base.py
+++ b/ultravox/inference/base.py
@@ -2,7 +2,7 @@ import abc
 import dataclasses
 from typing import Generator, List, Optional
 
-from ultravox.data import datasets
+from ultravox import data as datasets
 
 
 @dataclasses.dataclass

--- a/ultravox/inference/infer.py
+++ b/ultravox/inference/infer.py
@@ -8,7 +8,7 @@ import numpy as np
 import torch
 import transformers
 
-from ultravox.data import datasets
+from ultravox import data as datasets
 from ultravox.inference import base
 from ultravox.model import ultravox_processing
 

--- a/ultravox/inference/infer_test.py
+++ b/ultravox/inference/infer_test.py
@@ -5,7 +5,7 @@ import pytest
 import torch
 import transformers
 
-from ultravox.data import datasets
+from ultravox import data as datasets
 from ultravox.inference import base as infer_base
 from ultravox.inference import infer
 from ultravox.model import ultravox_processing

--- a/ultravox/model/data_processing.py
+++ b/ultravox/model/data_processing.py
@@ -1,17 +1,15 @@
 from typing import Any, Dict
 
-import datasets
 import numpy as np
-from torch.utils import data
 
-from ultravox.data import datasets
+from ultravox import data as datasets
 from ultravox.model import ultravox_processing
 
 
 class UltravoxDataproc(datasets.Dataproc):
     def __init__(
         self,
-        dataset: data.IterableDataset,
+        dataset: datasets.SizedIterableDataset,
         processor: ultravox_processing.UltravoxProcessor,
         train_on_inputs: bool = False,
         inference_mode: bool = False,

--- a/ultravox/model/data_processing_test.py
+++ b/ultravox/model/data_processing_test.py
@@ -4,7 +4,7 @@ import numpy as np
 import pytest
 import torch
 
-from ultravox.data import datasets
+from ultravox import data as datasets
 from ultravox.model import data_processing
 
 TEST_USER_MESSAGE = {

--- a/ultravox/tools/data_tool.py
+++ b/ultravox/tools/data_tool.py
@@ -3,7 +3,7 @@ import argparse
 import librosa
 import sounddevice as sd
 
-from ultravox.data import datasets
+from ultravox import data as datasets
 
 parser = argparse.ArgumentParser()
 parser.add_argument("data_sets", nargs="*", help="List of datasets to use")

--- a/ultravox/tools/gradio_demo.py
+++ b/ultravox/tools/gradio_demo.py
@@ -4,7 +4,7 @@ from typing import Optional
 import gradio as gr
 import simple_parsing
 
-from ultravox.data import datasets
+from ultravox import data as datasets
 from ultravox.inference import base as infer_base
 from ultravox.tools import gradio_helper
 

--- a/ultravox/tools/infer_api.py
+++ b/ultravox/tools/infer_api.py
@@ -8,7 +8,7 @@ import gradio_client
 import numpy as np
 import requests
 
-from ultravox.data import datasets
+from ultravox import data as datasets
 from ultravox.inference import base
 
 

--- a/ultravox/tools/infer_tool.py
+++ b/ultravox/tools/infer_tool.py
@@ -10,7 +10,7 @@ import numpy as np
 import simple_parsing
 from torch.utils import data as data_utils
 
-from ultravox.data import datasets
+from ultravox import data as datasets
 from ultravox.evaluation import eval
 from ultravox.evaluation import eval_types
 from ultravox.inference import base

--- a/ultravox/tools/push_to_hub.py
+++ b/ultravox/tools/push_to_hub.py
@@ -6,7 +6,6 @@ from typing import Optional
 import simple_parsing
 import transformers
 
-from ultravox import data
 from ultravox.inference import ultravox_infer
 from ultravox.model import ultravox_pipeline
 

--- a/ultravox/tools/push_to_hub.py
+++ b/ultravox/tools/push_to_hub.py
@@ -6,6 +6,7 @@ from typing import Optional
 import simple_parsing
 import transformers
 
+from ultravox import data as datasets
 from ultravox.inference import ultravox_infer
 from ultravox.model import ultravox_pipeline
 

--- a/ultravox/tools/push_to_hub.py
+++ b/ultravox/tools/push_to_hub.py
@@ -6,7 +6,7 @@ from typing import Optional
 import simple_parsing
 import transformers
 
-from ultravox.data import datasets
+from ultravox import data
 from ultravox.inference import ultravox_infer
 from ultravox.model import ultravox_pipeline
 

--- a/ultravox/training/config_base.py
+++ b/ultravox/training/config_base.py
@@ -10,7 +10,7 @@ from typing import Any, Dict, List, Optional
 import simple_parsing
 import torch
 
-from ultravox.data import datasets
+from ultravox import data as datasets
 from ultravox.model import ultravox_config
 
 

--- a/ultravox/training/evaluation.py
+++ b/ultravox/training/evaluation.py
@@ -8,7 +8,7 @@ from typing import List, Optional
 import numpy as np
 from torch.utils import data
 
-from ultravox.data import datasets
+from ultravox import data as datasets
 from ultravox.evaluation import eval
 from ultravox.evaluation import eval_types
 from ultravox.inference import infer

--- a/ultravox/training/train.py
+++ b/ultravox/training/train.py
@@ -18,7 +18,7 @@ import transformers
 import wandb
 import wandb.sdk
 
-from ultravox.data import datasets
+from ultravox import data as datasets
 from ultravox.model import data_processing
 from ultravox.model import ultravox_config
 from ultravox.model import ultravox_model


### PR DESCRIPTION
This splits out types.py and registry.py to move the list of pre-defined datasets to its own file and avoid circular refs.

An __all__ import is used to minimize changes to surrounding code.