### PR TITLE
Fix processor being overwritten by parent class

### DIFF
--- a/ultravox/model/ultravox_pipeline.py
+++ b/ultravox/model/ultravox_pipeline.py
@@ -32,14 +32,14 @@ class UltravoxPipeline(transformers.Pipeline):
             audio_processor = transformers.AutoProcessor.from_pretrained(
                 model.config.audio_model_id or model.config.audio_config._name_or_path
             )
-
+            
+        super().__init__(model=model, tokenizer=tokenizer, **kwargs)
+        
         self.processor = UltravoxProcessor(
             audio_processor=audio_processor,
             tokenizer=tokenizer,
             stack_factor=model.config.stack_factor,
         )
-
-        super().__init__(model=model, tokenizer=tokenizer, **kwargs)
 
     def _sanitize_parameters(self, **kwargs):
         generation_keys = ["temperature", "max_new_tokens", "repetition_penalty"]


### PR DESCRIPTION
In the most recent versions of `transformers`, the `Pipeline` parent class overrides `self.processor` and sets it to `None`. This PR side-steps that by changing the order in which `self.processor` is assigned.