### PR TITLE
Allow response generation with no user message

### DIFF
--- a/ultravox/inference/infer.py
+++ b/ultravox/inference/infer.py
@@ -57,10 +57,18 @@ class LocalInference(base.VoiceInference):
         self.past_key_values = past_key_values
 
     def _get_sample_with_past(
-        self, sample: datasets.VoiceSample
+        self, sample: Optional[datasets.VoiceSample] = None
     ) -> datasets.VoiceSample:
-        sample = copy.copy(sample)
-        sample.add_past_messages(self.past_messages)
+        # Workaround for if we want to generate an assistant response without a user query
+        if sample is None:
+            if len(self.past_messages) == 0:
+                raise ValueError("No past messages available to generate a response.")
+            sample = datasets.VoiceSample(
+                self.past_messages,
+            )
+        else:
+            sample = copy.copy(sample)
+            sample.add_past_messages(self.past_messages)
         return sample
 
     def _build_past_messages(
@@ -116,7 +124,7 @@ class LocalInference(base.VoiceInference):
 
     def infer(
         self,
-        sample: datasets.VoiceSample,
+        sample: Optional[datasets.VoiceSample] = None,
         max_tokens: Optional[int] = None,
         temperature: Optional[float] = None,
     ) -> base.VoiceOutput:
@@ -187,7 +195,7 @@ class LocalInference(base.VoiceInference):
 
     def infer_stream(
         self,
-        sample: datasets.VoiceSample,
+        sample: Optional[datasets.VoiceSample] = None,
         max_tokens: Optional[int] = None,
         temperature: Optional[float] = None,
     ) -> base.InferenceGenerator:


### PR DESCRIPTION
I may be wrong, but it is currently not possible to generate an assistant message without first inputting a user message.  This would allow for situations where you might want to generate an assistant message with just a system message prompt.  This PR allows for `sample` to be `None`, provided there are previous messages in the history (such as system messages).  I am not sure if this is the best implementation - so please let me know if it needs any changes!